### PR TITLE
[feat] 오늘의 습관 조회 UI 및 리스트 목업 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import StudyLayout from './layouts/StudyLayout';
 import StudyListPage from './pages/StudyListPage/StudyListPage';
 import TodayFocus from './pages/TodayFocusPage/TodayFocus';
 import LogPage from './pages/LogPage/LogPage';
+import TodayHabitPage from './pages/TodayHabitPage/TodayHabitPage';
 
 const App = () => {
   return (
@@ -17,6 +18,7 @@ const App = () => {
           {/* 각 페이지 <Route path="url" element={<페이지 컴포넌트 />} /> 로 추가하기 */}
           <Route path=":id/focus" element={<TodayFocus />} />
           <Route path=":id/logs" element={<LogPage />} />
+          <Route path=":id/habit" element={<TodayHabitPage />} />
         </Route>
       </Routes>
     </>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -16,9 +16,9 @@ const TodayHabitPage = () => {
             <div className={styles.top}>
               <h1 className={styles.title}>스터디명</h1>
               <nav className={styles.navContainer}>
-                <LinkButton text="오늘의 집중" url=":id/timer" />
-                <LinkButton text="로그" url=":id/logs" />
-                <LinkButton text="홈" url=":id/detail" />
+                <LinkButton text="오늘의 집중" url="/:id/focus" />
+                <LinkButton text="로그" url="/:id/logs" />
+                <LinkButton text="홈" url="/:id/detail" />
               </nav>
             </div>
             <div className={styles.time}>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -3,7 +3,10 @@ import styles from './TodayHabitPage.module.css';
 import LinkButton from '../../components/LinkButton/LinkButton';
 
 const TodayHabitPage = () => {
-  const mockHabits = [];
+  const mockHabits = [
+    { id: 1, name: '1번 습관', isCompleted: true },
+    { id: 2, name: '2번 습관', isCompleted: false },
+  ];
 
   return (
     <>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styles from './TodayHabitPage.module.css';
+import LinkButton from '../../components/LinkButton/LinkButton';
+
+const TodayHabitPage = () => {
+  const mockHabits = [];
+
+  return (
+    <>
+      <div className="wrapper">
+        <div className={styles.bodyWrapper}>
+          <section className={styles.header}>
+            <div className={styles.top}>
+              <h1 className={styles.title}>스터디명</h1>
+              <nav className={styles.navContainer}>
+                <LinkButton text="오늘의 집중" url=":id/timer" />
+                <LinkButton text="로그" url=":id/logs" />
+                <LinkButton text="홈" url=":id/detail" />
+              </nav>
+            </div>
+            <div className={styles.time}>
+              <p className={styles.timeTxt}>현재 시간</p>
+              <div className={styles.nowTime}>시계</div>
+            </div>
+          </section>
+          <section className={styles.mainSection}>
+            <div className={styles.todayHabit}>
+              <div className={styles.listHeader}>
+                <h2 className={styles.listTitle}>오늘의 습관</h2>
+                <button className={styles.listConfirm}>목록 수정</button>
+              </div>
+              <div className={styles.habitList}>
+                {mockHabits.length === 0 ? (
+                  <div className={styles.emptyMessage}>
+                    <p>아직 습관이 없어요</p>
+                    <p>목록 수정을 눌러 습관을 생성해보세요</p>
+                  </div>
+                ) : (
+                  mockHabits.map((h) => (
+                    <div
+                      key={h.id}
+                      className={`${styles.habitItem} ${h.isCompleted ? styles.completed : styles.notComplete}`}
+                    >
+                      {h.name}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default TodayHabitPage;

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -12,7 +12,6 @@
 
 .top {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   width: 100%;
 }
@@ -24,7 +23,6 @@
 
 .navContainer {
   display: flex;
-  flex-direction: row;
   gap: 16px;
 }
 

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -102,6 +102,7 @@
   flex-direction: column;
   gap: 20px;
   width: 100%;
+  height: 498px;
 }
 
 .habitItem {

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -1,0 +1,141 @@
+.bodyWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.top {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 800;
+}
+
+.navContainer {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.time {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.timeTxt {
+  color: var(--gray_818181);
+  font-size: 18px;
+  font-weight: 400;
+}
+
+.nowTime {
+  width: fit-content;
+  padding: 8px 12px;
+  border-radius: 50px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.mainSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 45px;
+
+  padding: 40px 24px;
+  border-radius: 20px;
+  border: 1px solid var(--gray_DDDDDD);
+  background: var(--white_FFFFFF);
+}
+
+.todayHabit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+
+  width: 400px;
+}
+
+.listHeader {
+  position: relative;
+  width: 100%;
+  display: flex;
+}
+.listTitle {
+  width: 100%;
+  text-align: center;
+
+  color: var(--black_414141, #414141);
+  font-size: 24px;
+  font-weight: 800;
+}
+
+.listConfirm {
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  padding: 8px 12px;
+  color: var(--gray_818181);
+  text-align: right;
+  font-size: 14px;
+  font-weight: 500;
+  background: none;
+  border: none;
+}
+
+.habitList {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+}
+
+.habitItem {
+  display: flex;
+  width: 100%;
+  height: 54px;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 20px;
+
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.completed {
+  background-color: var(--brand_99C08E);
+  color: var(--white_FFFFFF);
+}
+
+.notComplete {
+  background-color: var(--gray_EEEEEE);
+  color: var(--gray_818181);
+}
+
+.emptyMessage {
+  display: flex;
+  width: 100%;
+  height: 498px;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+
+  color: var(--gray_818181);
+  font-size: 20px;
+  font-weight: 500;
+}

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -138,3 +138,47 @@
   font-size: 20px;
   font-weight: 500;
 }
+
+/* 태블릿 */
+@media (max-width: 1024px) {
+  .bodyWrapper {
+    gap: 40px;
+  }
+}
+
+/* 모바일 */
+@media (max-width: 768px) {
+  .bodyWrapper {
+    gap: 24px;
+  }
+  .top {
+    flex-direction: column;
+    gap: 16px;
+  }
+  .title {
+    font-size: 24px;
+  }
+  .navContainer {
+    gap: 8px;
+  }
+  .mainSection {
+    gap: 10px;
+
+    padding: 24px 16px;
+    border-radius: 20px;
+    border: 1px solid var(--gray_DDDDDD);
+    background: var(--white_FFFFFF);
+  }
+  .listTitle {
+    font-size: 18px;
+  }
+  .habitList {
+    gap: 12px;
+    height: 450px;
+  }
+  .emptyMessage {
+    height: 474px;
+
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 오늘의 습관 조회 페이지의 UI를 구현하고, 목업 데이터를 기반으로 리스트 렌더링을 적용했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- TodayHabitPage 레이아웃 및 UI 구성
- 목업 데이터를 활용한 습관 리스트 렌더링 구현
- 완료/미완료 상태에 따른 스타일 분기 처리
- 습관 리스트 empty 상태 UI 구현
- 상단 헤더 및 기본 레이아웃 구조 구성

## 📷 스크린샷 (선택사항)

<img width="610" height="460" alt="image" src="https://github.com/user-attachments/assets/58da0530-c2df-445d-96db-94aa0d1a69d7" />


<img width="608" height="462" alt="image" src="https://github.com/user-attachments/assets/a52f75cf-9097-49cb-a769-2a936f3317c3" />


## 📦 참고사항 (선택사항)

> 현재 시간 표시 및 반응형은 이후 작업 예정입니다.

close #15 