### PR TITLE
[Feat] 오늘의 습관 조회 및 생성 기능 프론트-백엔드 연동

### DIFF
--- a/src/components/HabitComponents/HabitConfirmModal.jsx
+++ b/src/components/HabitComponents/HabitConfirmModal.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import HabitModal from '../Modal/HabitModal/HabitModal';
+import HabitCreateForm from './HabitCreateForm';
+
+const HabitConfirmModal = ({ onClose, onConfirm, newHabit, setNewHabit }) => {
+  return (
+    <>
+      <HabitModal title="습관 목록" onClose={onClose} onConfirm={onConfirm}>
+        <HabitCreateForm newHabit={newHabit} setNewHabit={setNewHabit} />
+      </HabitModal>
+    </>
+  );
+};
+
+export default HabitConfirmModal;

--- a/src/components/HabitComponents/HabitCreateForm.jsx
+++ b/src/components/HabitComponents/HabitCreateForm.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const HabitCreateForm = ({ newHabit, setNewHabit }) => {
+  return (
+    <>
+      <div>
+        <input value={newHabit} onChange={(e) => setNewHabit(e.target.value)} />
+      </div>
+    </>
+  );
+};
+
+export default HabitCreateForm;

--- a/src/components/HabitComponents/HabitHeader.jsx
+++ b/src/components/HabitComponents/HabitHeader.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from '../../pages/TodayHabitPage/TodayHabitPage.module.css';
+import LinkButton from '../../components/LinkButton/LinkButton';
+
+const HabitHeader = ({ studyName, id }) => {
+  return (
+    <>
+      <div className={styles.top}>
+        <h1 className={styles.title}>{studyName}</h1>
+        <nav className={styles.navContainer}>
+          <LinkButton text="오늘의 집중" url={`/${id}/focus`} />
+          <LinkButton text="로그" url={`/${id}/logs`} />
+          <LinkButton text="홈" url={`/${id}/detail`} />
+        </nav>
+      </div>
+    </>
+  );
+};
+
+export default HabitHeader;

--- a/src/components/HabitComponents/HabitList.jsx
+++ b/src/components/HabitComponents/HabitList.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styles from '../../pages/TodayHabitPage/TodayHabitPage.module.css';
+
+const HabitList = ({ habits }) => {
+  return (
+    <>
+      <div className={styles.habitList}>
+        {habits.length === 0 ? (
+          <div className={styles.emptyMessage}>
+            <p>아직 습관이 없어요</p>
+            <p>목록 수정을 눌러 습관을 생성해보세요</p>
+          </div>
+        ) : (
+          habits.map((h) => (
+            <div
+              key={h.id}
+              className={`${styles.habitItem} ${h.isCompleted ? styles.completed : styles.notComplete}`}
+            >
+              {h.name}
+            </div>
+          ))
+        )}
+      </div>
+    </>
+  );
+};
+
+export default HabitList;

--- a/src/components/HabitComponents/HabitListHeader.jsx
+++ b/src/components/HabitComponents/HabitListHeader.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from '../../pages/TodayHabitPage/TodayHabitPage.module.css';
+
+const HabitListHeader = ({ onOpenModal }) => {
+  return (
+    <>
+      <div className={styles.listHeader}>
+        <h2 className={styles.listTitle}>오늘의 습관</h2>
+        <button className={styles.listConfirm} onClick={onOpenModal}>
+          목록 수정
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default HabitListHeader;

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -4,16 +4,19 @@ import LinkButton from '../../components/LinkButton/LinkButton';
 import HabitList from '../../components/HabitComponents/HabitList';
 import HabitListHeader from '../../components/HabitComponents/HabitListHeader';
 import { useParams } from 'react-router-dom';
+import HabitConfirmModal from '../../components/HabitComponents/HabitConfirmModal';
 
 const TodayHabitPage = () => {
-  const [habits, setHabits] = useState([]);
   const [studyName, setStudyName] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newHabit, setNewHabit] = useState('');
+  const [habits, setHabits] = useState([]);
 
   const { id } = useParams();
 
   const fetchTodayHabits = async () => {
     try {
-      const response = await fetch(`/api/studies/${id}/habits/today`);
+      const response = await fetch(`/api/habits/${id}/today`);
       const result = await response.json();
 
       console.log(result);
@@ -28,7 +31,36 @@ const TodayHabitPage = () => {
   }, []);
 
   const onOpenModalHandler = () => {
-    console.log('모달 열기');
+    setIsModalOpen(true);
+  };
+
+  const onCloseModalHandler = () => {
+    setIsModalOpen(false);
+    setNewHabit('');
+  };
+
+  const createHabit = async () => {
+    if (!newHabit.trim()) return;
+
+    try {
+      const response = await fetch(`/api/habits/${id}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: newHabit }),
+      });
+
+      const result = await response.json();
+
+      if (!result.success) return;
+
+      setNewHabit('');
+      onCloseModalHandler();
+      fetchTodayHabits();
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -57,6 +89,14 @@ const TodayHabitPage = () => {
           </section>
         </div>
       </div>
+      {isModalOpen && (
+        <HabitConfirmModal
+          onClose={onCloseModalHandler}
+          onConfirm={createHabit}
+          newHabit={newHabit}
+          setNewHabit={setNewHabit}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -12,6 +12,7 @@ const TodayHabitPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newHabit, setNewHabit] = useState('');
   const [habits, setHabits] = useState([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { id } = useParams();
 
@@ -63,9 +64,11 @@ const TodayHabitPage = () => {
 
   // 습관 생성
   const createHabit = async () => {
-    if (!newHabit.trim()) return;
+    if (!newHabit.trim() || isSubmitting) return;
 
     try {
+      setIsSubmitting(true);
+
       const response = await fetch(`/api/habits/${id}`, {
         method: 'POST',
         headers: {
@@ -82,6 +85,8 @@ const TodayHabitPage = () => {
       fetchTodayHabits();
     } catch (error) {
       console.error(error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './TodayHabitPage.module.css';
 import LinkButton from '../../components/LinkButton/LinkButton';
+import HabitList from '../../components/HabitComponents/HabitList';
+import HabitListHeader from '../../components/HabitComponents/HabitListHeader';
+import { useParams } from 'react-router-dom';
 
 const TodayHabitPage = () => {
-  const mockHabits = [
-    { id: 1, name: '1번 습관', isCompleted: true },
-    { id: 2, name: '2번 습관', isCompleted: false },
-  ];
+  const [habits, setHabits] = useState([]);
+  const [studyName, setStudyName] = useState('');
+
+  const { id } = useParams();
+
+  const fetchTodayHabits = async () => {
+    try {
+      const response = await fetch(`/api/studies/${id}/habits/today`);
+      const result = await response.json();
+
+      console.log(result);
+      setHabits(result.data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchTodayHabits();
+  }, []);
+
+  const onOpenModalHandler = () => {
+    console.log('모달 열기');
+  };
 
   return (
     <>
@@ -28,27 +51,8 @@ const TodayHabitPage = () => {
           </section>
           <section className={styles.mainSection}>
             <div className={styles.todayHabit}>
-              <div className={styles.listHeader}>
-                <h2 className={styles.listTitle}>오늘의 습관</h2>
-                <button className={styles.listConfirm}>목록 수정</button>
-              </div>
-              <div className={styles.habitList}>
-                {mockHabits.length === 0 ? (
-                  <div className={styles.emptyMessage}>
-                    <p>아직 습관이 없어요</p>
-                    <p>목록 수정을 눌러 습관을 생성해보세요</p>
-                  </div>
-                ) : (
-                  mockHabits.map((h) => (
-                    <div
-                      key={h.id}
-                      className={`${styles.habitItem} ${h.isCompleted ? styles.completed : styles.notComplete}`}
-                    >
-                      {h.name}
-                    </div>
-                  ))
-                )}
-              </div>
+              <HabitListHeader onOpenModal={onOpenModalHandler} />
+              <HabitList habits={habits} />
             </div>
           </section>
         </div>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import styles from './TodayHabitPage.module.css';
-import LinkButton from '../../components/LinkButton/LinkButton';
 import HabitList from '../../components/HabitComponents/HabitList';
 import HabitListHeader from '../../components/HabitComponents/HabitListHeader';
 import { useParams } from 'react-router-dom';
 import HabitConfirmModal from '../../components/HabitComponents/HabitConfirmModal';
+import CurrentTime from '../../components/CurrentTime/CurrentTime';
+import HabitHeader from '../../components/HabitComponents/HabitHeader';
 
 const TodayHabitPage = () => {
   const [studyName, setStudyName] = useState('');
@@ -14,12 +15,30 @@ const TodayHabitPage = () => {
 
   const { id } = useParams();
 
+  // 스터디명 조회
+  const fetchStudy = async () => {
+    try {
+      const response = await fetch('/api/studies');
+      const result = await response.json();
+
+      if (!result.success) return;
+
+      const currentStudy = result.data.find((study) => study.id === Number(id));
+
+      if (!currentStudy) return;
+
+      setStudyName(currentStudy.title);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  // 습관 조회
   const fetchTodayHabits = async () => {
     try {
       const response = await fetch(`/api/habits/${id}/today`);
       const result = await response.json();
 
-      console.log(result);
       setHabits(result.data);
     } catch (error) {
       console.error(error);
@@ -28,17 +47,21 @@ const TodayHabitPage = () => {
 
   useEffect(() => {
     fetchTodayHabits();
-  }, []);
+    fetchStudy();
+  }, [id]);
 
+  // 모달 열기
   const onOpenModalHandler = () => {
     setIsModalOpen(true);
   };
 
+  // 모달 닫기
   const onCloseModalHandler = () => {
     setIsModalOpen(false);
     setNewHabit('');
   };
 
+  // 습관 생성
   const createHabit = async () => {
     if (!newHabit.trim()) return;
 
@@ -55,7 +78,6 @@ const TodayHabitPage = () => {
 
       if (!result.success) return;
 
-      setNewHabit('');
       onCloseModalHandler();
       fetchTodayHabits();
     } catch (error) {
@@ -68,18 +90,8 @@ const TodayHabitPage = () => {
       <div className="wrapper">
         <div className={styles.bodyWrapper}>
           <section className={styles.header}>
-            <div className={styles.top}>
-              <h1 className={styles.title}>스터디명</h1>
-              <nav className={styles.navContainer}>
-                <LinkButton text="오늘의 집중" url="/:id/focus" />
-                <LinkButton text="로그" url="/:id/logs" />
-                <LinkButton text="홈" url="/:id/detail" />
-              </nav>
-            </div>
-            <div className={styles.time}>
-              <p className={styles.timeTxt}>현재 시간</p>
-              <div className={styles.nowTime}>시계</div>
-            </div>
+            <HabitHeader studyName={studyName} id={id} />
+            <CurrentTime />
           </section>
           <section className={styles.mainSection}>
             <div className={styles.todayHabit}>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -6,6 +6,11 @@ import { useParams } from 'react-router-dom';
 import HabitConfirmModal from '../../components/HabitComponents/HabitConfirmModal';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 import HabitHeader from '../../components/HabitComponents/HabitHeader';
+import {
+  getStudyName,
+  getTodayHabits,
+  postHabit,
+} from '../../services/HabitService';
 
 const TodayHabitPage = () => {
   const [studyName, setStudyName] = useState('');
@@ -16,39 +21,27 @@ const TodayHabitPage = () => {
 
   const { id } = useParams();
 
-  // 스터디명 조회
   const fetchStudy = async () => {
     try {
-      const response = await fetch('/api/studies');
-      const result = await response.json();
-
-      if (!result.success) return;
-
-      const currentStudy = result.data.find((study) => study.id === Number(id));
-
-      if (!currentStudy) return;
-
-      setStudyName(currentStudy.title);
+      const title = await getStudyName(id);
+      setStudyName(title);
     } catch (error) {
       console.error(error);
     }
   };
 
-  // 습관 조회
-  const fetchTodayHabits = async () => {
+  const fetchHabits = async () => {
     try {
-      const response = await fetch(`/api/habits/${id}/today`);
-      const result = await response.json();
-
-      setHabits(result.data);
+      const data = await getTodayHabits(id);
+      setHabits(data);
     } catch (error) {
       console.error(error);
     }
   };
 
   useEffect(() => {
-    fetchTodayHabits();
     fetchStudy();
+    fetchHabits();
   }, [id]);
 
   // 모달 열기
@@ -62,27 +55,16 @@ const TodayHabitPage = () => {
     setNewHabit('');
   };
 
-  // 습관 생성
   const createHabit = async () => {
-    if (!newHabit.trim() || isSubmitting) return;
+    if (!newHabit.trim() || isSubmitting) {
+      return;
+    }
 
     try {
       setIsSubmitting(true);
-
-      const response = await fetch(`/api/habits/${id}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ name: newHabit }),
-      });
-
-      const result = await response.json();
-
-      if (!result.success) return;
-
+      await postHabit(id, newHabit);
       onCloseModalHandler();
-      fetchTodayHabits();
+      fetchHabits();
     } catch (error) {
       console.error(error);
     } finally {

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -174,10 +174,10 @@
   }
   .habitList {
     gap: 12px;
-    height: 450px;
+    min-height: 450px;
   }
   .emptyMessage {
-    height: 474px;
+    min-height: 474px;
 
     font-size: 16px;
   }

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -100,13 +100,13 @@
   flex-direction: column;
   gap: 20px;
   width: 100%;
-  height: 498px;
+  min-height: 498px;
 }
 
 .habitItem {
   display: flex;
   width: 100%;
-  height: 54px;
+  min-height: 54px;
   justify-content: center;
   align-items: center;
 
@@ -129,7 +129,7 @@
 .emptyMessage {
   display: flex;
   width: 100%;
-  height: 498px;
+  min-height: 498px;
   justify-content: center;
   align-items: center;
   flex-direction: column;

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -26,26 +26,6 @@
   gap: 16px;
 }
 
-.time {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.timeTxt {
-  color: var(--gray_818181);
-  font-size: 18px;
-  font-weight: 400;
-}
-
-.nowTime {
-  width: fit-content;
-  padding: 8px 12px;
-  border-radius: 50px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  background: rgba(255, 255, 255, 0.3);
-}
-
 .mainSection {
   display: flex;
   flex-direction: column;

--- a/src/services/HabitService.js
+++ b/src/services/HabitService.js
@@ -1,0 +1,45 @@
+export const getStudyName = async (id) => {
+  const response = await fetch('http://localhost:8080/api/studies');
+  const result = await response.json();
+
+  if (!response.ok || !result.success) {
+    throw new Error(result.message || '스터디 조회를 실패했습니다.');
+  }
+
+  const currentStudy = result.data.find((study) => study.id === Number(id));
+
+  if (!currentStudy) {
+    throw new Error('스터디를 찾을 수 없습니다.');
+  }
+
+  return currentStudy.title;
+};
+
+export const getTodayHabits = async (id) => {
+  const response = await fetch(`http://localhost:8080/api/habits/${id}/today`);
+  const result = await response.json();
+
+  if (!response.ok || !result.success) {
+    throw new Error(result.message || '습관 조회를 실패했습니다');
+  }
+
+  return result.data;
+};
+
+export const postHabit = async (id, name) => {
+  const response = await fetch(`http://localhost:8080/api/habits/${id}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  const result = await response.json();
+
+  if (!response.ok || !result.success) {
+    throw new Error(result.message || '습관 생성을 실패했습니다.');
+  }
+
+  return result.data;
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,12 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,9 +4,4 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      '/api': 'http://localhost:8080',
-    },
-  },
 });


### PR DESCRIPTION
## 🔥 Related Issues


- close #46 



## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 오늘의 습관 조회 및 생성 기능을 구현하고, 프론트-백엔드 연동과 UI 구조를 정리했습니다.

## 🛠️ 작업 내용


> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 오늘의 습관 조회 API 연결 (GET /api/habits/:studyId/today)
- 오늘의 습관 생성 API 연결 (POST /api/habits/:studyId)
- 생성 후 리스트 재조회 처리
- 습관 생성 시 연속 클릭으로 인한 중복 요청 방지 처리
- 스터디 목록 API(/api/studies)를 활용하여 현재 스터디명 조회 및 화면 반영
- HabitHeader, HabitList, HabitListHeader 컴포넌트 분리
- HabitConfirmModal, HabitModal, HabitCreateForm 구조 분리 및 모달 연동
- 습관 API 라우터 경로 구조 수정 및 프론트 연동 반영
- 페이지에 min-height 적용

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

<img width="538" height="218" alt="image" src="https://github.com/user-attachments/assets/da071b6b-e223-49bf-889d-52a5d970887b" />

<img width="964" height="494" alt="image" src="https://github.com/user-attachments/assets/f42ed358-93ed-4557-a742-b4c449a78f27" />


## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `
