### PR TITLE
[Feat] 검색/정렬/페이지네이션 fetch 함수 구현

### DIFF
--- a/src/components/StudyComponents/StudyList/Pagination.jsx
+++ b/src/components/StudyComponents/StudyList/Pagination.jsx
@@ -1,14 +1,34 @@
-import React from 'react';
 import styles from './Pagination.module.css';
 
-// 현재 하드코딩으로 1부터 5까지 ui만 구현되어 있음
-const Pagination = ({ currentPage = 1, pages = [1, 2, 3, 4, 5] }) => {
+const Pagination = ({
+  currentPage = 1,
+  totalPages = 1,
+  onPageChange,
+}) => {
+  if (totalPages <= 0) {
+    return null;
+  }
+
+  const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+
   return (
     <nav className={styles.pagination} aria-label="페이지네이션">
-      <button type="button" className={styles.navButton} aria-label="첫 페이지">
+      <button
+        type="button"
+        className={styles.navButton}
+        aria-label="첫 페이지"
+        onClick={() => onPageChange(1)}
+        disabled={currentPage === 1}
+      >
         &lt;&lt;
       </button>
-      <button type="button" className={styles.navButton} aria-label="이전 페이지">
+      <button
+        type="button"
+        className={styles.navButton}
+        aria-label="이전 페이지"
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
         &lt;
       </button>
 
@@ -22,6 +42,7 @@ const Pagination = ({ currentPage = 1, pages = [1, 2, 3, 4, 5] }) => {
               type="button"
               className={`${styles.pageButton} ${isActive ? styles.active : ''}`}
               aria-current={isActive ? 'page' : undefined}
+              onClick={() => onPageChange(page)}
             >
               {page}
             </button>
@@ -29,10 +50,22 @@ const Pagination = ({ currentPage = 1, pages = [1, 2, 3, 4, 5] }) => {
         })}
       </div>
 
-      <button type="button" className={styles.navButton} aria-label="다음 페이지">
+      <button
+        type="button"
+        className={styles.navButton}
+        aria-label="다음 페이지"
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+      >
         &gt;
       </button>
-      <button type="button" className={styles.navButton} aria-label="마지막 페이지">
+      <button
+        type="button"
+        className={styles.navButton}
+        aria-label="마지막 페이지"
+        onClick={() => onPageChange(totalPages)}
+        disabled={currentPage === totalPages}
+      >
         &gt;&gt;
       </button>
     </nav>

--- a/src/components/StudyComponents/StudyList/Search.jsx
+++ b/src/components/StudyComponents/StudyList/Search.jsx
@@ -1,13 +1,26 @@
-import React from 'react';
 import styles from './Search.module.css';
 import searchIcon from '../../../assets/icons/ic_search.svg';
 
-const Search = () => {
+const Search = ({ value, onChange, onSubmit }) => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(value);
+  };
+
+  const handleChange = (e) => {
+    onChange(e.target.value);
+  };
+
   return (
-    <div className={styles.searchField}>
+    <form className={styles.searchField} onSubmit={handleSubmit}>
       <img src={searchIcon} alt="" className={styles.searchIcon} />
-      <input className={styles.input} placeholder="검색" />
-    </div>
+      <input
+        className={styles.input}
+        placeholder="검색"
+        value={value}
+        onChange={handleChange}
+      />
+    </form>
   );
 };
 

--- a/src/components/StudyComponents/StudyList/Sort.jsx
+++ b/src/components/StudyComponents/StudyList/Sort.jsx
@@ -1,15 +1,26 @@
-import React from 'react';
 import styles from './Sort.module.css';
 import toggleIcon from '../../../assets/icons/ic_toggle.svg';
 
-const Sort = () => {
+const SORT_OPTIONS = [
+  { value: 'latest', label: '최신순' },
+  { value: 'oldest', label: '오래된순' },
+  { value: 'mostPoints', label: '포인트 많은 순' },
+  { value: 'leastPoints', label: '포인트 적은 순' },
+];
+
+const Sort = ({ value, onChange }) => {
+  const handleChange = (e) => {
+    onChange(e.target.value);
+  };
+
   return (
     <div className={styles.selectWrapper}>
-      <select className={styles.select}>
-        <option>최근 순</option>
-        <option>오래된 순</option>
-        <option>많은 포인트 순</option>
-        <option>적은 포인트 순</option>
+      <select className={styles.select} value={value} onChange={handleChange}>
+        {SORT_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
       </select>
       <img src={toggleIcon} alt="" className={styles.toggleIcon} />
     </div>

--- a/src/pages/StudyListPage/StudyListPage.jsx
+++ b/src/pages/StudyListPage/StudyListPage.jsx
@@ -3,71 +3,122 @@ import Card from '../../components/StudyComponents/StudyList/Card';
 import Pagination from '../../components/StudyComponents/StudyList/Pagination';
 import Search from '../../components/StudyComponents/StudyList/Search';
 import Sort from '../../components/StudyComponents/StudyList/Sort';
-import {
-  getRecentStudyList,
-  getStudyList,
-} from '../../services/StudyService';
+import { getRecentStudyList, getStudyList } from '../../services/StudyService';
 import styles from './StudyListPage.module.css';
+
+const PAGE_SIZE = 6;
 
 const StudyList = () => {
   const [studyList, setStudyList] = useState([]);
   const [recentStudyList, setRecentStudyList] = useState([]);
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [orderBy, setOrderBy] = useState('latest');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pagination, setPagination] = useState({
+    currentPage: 1,
+    pageSize: PAGE_SIZE,
+    totalCount: 0,
+    totalPages: 1,
+  });
 
   useEffect(() => {
     const fetchStudyList = async () => {
       try {
-        const data = await getStudyList();
-        setStudyList(data);
+        const result = await getStudyList({
+          page: currentPage,
+          pageSize: PAGE_SIZE,
+          keyword,
+          orderBy,
+        });
+        const recentStudies = getRecentStudyList();
+
+        setStudyList(result.studies);
+        setPagination(
+          result.pagination ?? {
+            currentPage,
+            pageSize: PAGE_SIZE,
+            totalCount: result.studies.length,
+            totalPages: 1,
+          },
+        );
+        setRecentStudyList(recentStudies);
       } catch (error) {
         console.error(error);
       }
     };
 
     fetchStudyList();
-    setRecentStudyList(getRecentStudyList());
-  }, []);
+  }, [currentPage, keyword, orderBy]);
+
+  const handleSearchChange = (value) => {
+    setSearchKeyword(value);
+  };
+
+  const handleSearchSubmit = (value) => {
+    setKeyword(value.trim());
+    setCurrentPage(1);
+  };
+
+  const handleSortChange = (nextOrderBy) => {
+    setOrderBy(nextOrderBy);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page) => {
+    if (page < 1 || page > pagination.totalPages || page === currentPage) {
+      return;
+    }
+
+    setCurrentPage(page);
+  };
 
   return (
     <main className={styles.page}>
       <div className="wrapper">
-        {/* 최근 조회한 스터디 */}
         <section className={styles.section}>
           <h2 className={styles.sectionTitle}>최근 조회한 스터디</h2>
           <div className={styles.recentGrid}>
             {recentStudyList.length === 0 ? (
               <h2>아직 조회한 스터디가 없어요</h2>
             ) : (
-              recentStudyList.map((study) => <Card key={study.id} study={study} />)
+              recentStudyList.map((study) => (
+                <Card key={study.id} study={study} />
+              ))
             )}
           </div>
         </section>
       </div>
 
       <div className="wrapper">
-        {/* 스터디 둘러보기 */}
         <section className={styles.section}>
           <div className={styles.sectionHeader}>
             <h2 className={styles.sectionTitle}>스터디 둘러보기</h2>
           </div>
 
           <div className={styles.controlsRow}>
-            {/* 검색 */}
-            <Search />
-            {/* 정렬 */}
-            <Sort />
+            <Search
+              value={searchKeyword}
+              onChange={handleSearchChange}
+              onSubmit={handleSearchSubmit}
+            />
+            <Sort value={orderBy} onChange={handleSortChange} />
           </div>
 
           <div className={styles.cardGrid}>
             {studyList.length === 0 ? (
-              <h2> 아직 둘러 볼 스터디가 없어요</h2>
+              <h2>조건에 맞는 스터디가 없어요</h2>
             ) : (
               studyList.map((study) => <Card key={study.id} study={study} />)
             )}
           </div>
 
-          {/* 페이지네이션 */}
           <div className={styles.paginationWrapper}>
-            <Pagination currentPage={1} pages={[1, 2, 3, 4, 5]} />
+            <Pagination
+              currentPage={pagination.currentPage}
+              totalPages={pagination.totalPages}
+              onPageChange={handlePageChange}
+            />
           </div>
         </section>
       </div>

--- a/src/services/StudyService.js
+++ b/src/services/StudyService.js
@@ -1,7 +1,7 @@
 const STUDY_API_URL = 'http://localhost:8080/api/studies';
 const RECENT_STUDY_LIST_KEY = 'recentStudyList';
 
-// N일째 진행 중 데이터 계산
+////////////////// N일째 진행 중 데이터 계산 //////////////////
 const getStudyProgressText = (createdAt) => {
   if (!createdAt) {
     return '';
@@ -12,7 +12,10 @@ const getStudyProgressText = (createdAt) => {
   const createdDate = new Date(`${createdDateText}T00:00:00`);
   const todayDate = new Date(`${todayDateText}T00:00:00`);
 
-  if (Number.isNaN(createdDate.getTime()) || Number.isNaN(todayDate.getTime())) {
+  if (
+    Number.isNaN(createdDate.getTime()) ||
+    Number.isNaN(todayDate.getTime())
+  ) {
     return '';
   }
 
@@ -22,7 +25,7 @@ const getStudyProgressText = (createdAt) => {
   return `${diffDays + 1}일째 진행 중`;
 };
 
-// 스터디 데이터 
+// 스터디 데이터
 const normalizeStudy = (study) => ({
   id: study.id,
   nickname: study.nickname ?? '',
@@ -38,33 +41,42 @@ const normalizeStudy = (study) => ({
   heartCount: study.heartCount ?? 0,
 });
 
-const extractStudyList = (payload) => {
-  if (Array.isArray(payload)) {
-    return payload;
+////////////////// 스터디 목록 불러오기 //////////////////
+export const getStudyList = async ({
+  page = 1,
+  pageSize = 6,
+  keyword = '',
+  orderBy = 'latest',
+} = {}) => {
+  const searchParams = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+    orderBy,
+  });
+
+  if (keyword.trim()) {
+    searchParams.set('keyword', keyword.trim());
   }
 
-  if (Array.isArray(payload?.data)) {
-    return payload.data;
-  }
-
-  return [];
-};
-
-// 스터디 목록 불러오기
-export const getStudyList = async () => {
-  const response = await fetch(STUDY_API_URL);
+  const response = await fetch(`${STUDY_API_URL}?${searchParams.toString()}`);
 
   if (!response.ok) {
     throw new Error('스터디 목록을 불러오지 못했습니다.');
   }
 
-  const data = await response.json();
-  const studyList = extractStudyList(data);
+  const result = await response.json();
+  const studies = result?.data?.studies ?? [];
+  const pagination = result?.data?.pagination ?? null;
+  const filters = result?.data?.filters ?? null;
 
-  return studyList.map(normalizeStudy);
+  return {
+    studies: studies.map(normalizeStudy),
+    pagination,
+    filters,
+  };
 };
 
-// 로컬 스토리지 사용하여 최근 스터디 목록 불러오기
+////////////////// 로컬 스토리지 사용하여 최근 스터디 목록 불러오기 //////////////////
 export const getRecentStudyList = () => {
   const storedValue = localStorage.getItem(RECENT_STUDY_LIST_KEY);
 
@@ -82,7 +94,7 @@ export const getRecentStudyList = () => {
   }
 };
 
-//로컬스토리지에 최근 조회 목록 저장
+////////////////// 로컬스토리지에 최근 조회 목록 저장 //////////////////
 export const saveRecentStudy = (study) => {
   const recentStudyList = getRecentStudyList();
   const filteredStudyList = recentStudyList.filter(


### PR DESCRIPTION
## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 11주차
- **PR 요약**: 구현한 기능 혹은 해당 PR의 내용을 요약

검색/정렬/페이지네이션 fetch 함수 구현
---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

- 검색 정렬 페이지네이션 상태 관리
- 검색 정렬 페이지네이션 조건에 따라 서버에서 리스트 받아오기

---

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **요청 내용**:
  > 현재 검색, 정렬, 페이지네이션을 프론트에서 상태( useState )로 관리하고 있는데 제가 searchKeyword, keyword, orderBy, currentPage를 분리해서 사용하고 있는데 역할별 상태를 잘 나눴는지 모르겠어서 확인 한번 부탁드립니다. 
제가 searchKeyword랑 keyword를 나눈 이유는 입력 중인 검색어 /실제 조회에 반영되는 검색어 를 분리하기 위함인데 분리하고 나니까 사실 입력 중인 검색어는 관리할 필요가 없나 싶기도 해서 이 부분도 확인 요청 드립니다.

또 useEffect 안에서 상태값 currentPage, keyword, orderBy이 바뀔 때마다 계속 다시 호출하고 있는 구조인데, 데이터 조회 방식에 있어서 적절한지 궁금합니다. 

감사합니다!