### PR TITLE
[Feat] 공유, 삭제, 주간 습관 조회 기능 구현

### DIFF
--- a/src/components/StudyDetailComponents/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
+++ b/src/components/StudyDetailComponents/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
@@ -16,7 +16,6 @@ const EmojiAdd = ({ emojis, setEmojis, id }) => {
     // emoji 가 현재 emoji 안에 있는 지 확인
     // 있으면 patch 로 넘기고
     // 없으면 create 로 넘기자!
-
     const selectEmoji = emojis.find((emoji) => emoji.emoji === e.emoji);
 
     if (!selectEmoji) {

--- a/src/components/StudyDetailComponents/Emoji/EmojiPopOver/EmojiMore/EmojiMore.jsx
+++ b/src/components/StudyDetailComponents/Emoji/EmojiPopOver/EmojiMore/EmojiMore.jsx
@@ -14,8 +14,7 @@ const EmojiMore = ({ data }) => {
         className={styles.emojiMoreBtn}
         onClick={() => setIsOpen(!isOpen)}
       >
-        <img src={plusIcon} alt="이모지 더보기" /> {data.slice(3).length}
-        ..
+        <img src={plusIcon} alt="이모지 더보기" /> {data.slice(3).length}..
       </button>
       {isOpen && (
         <div className={styles.emojiMoreBox}>

--- a/src/components/StudyDetailComponents/HabitTable/HabitTable.jsx
+++ b/src/components/StudyDetailComponents/HabitTable/HabitTable.jsx
@@ -1,37 +1,51 @@
 import HabitItems from './HabitItems/HabitItems';
 import styles from '../HabitTable/HabitTable.module.css';
+import { useEffect, useState } from 'react';
+import { getWeeklyHabits } from '../../../services/StudyDetailService';
 
-const HabitTable = () => {
-  const datas = [
-    {
-      title: '미라클모닝 6시 기상',
-      isCompleted: [true, true, false, true, false, false, false],
-    },
-    {
-      title: '아침 챙겨 먹기',
-      isCompleted: [true, true, false, true, false, false, true],
-    },
-    {
-      title: 'React 스터디 책 1챕터 읽기',
-      isCompleted: [false, true, false, true, false, true, false],
-    },
-    {
-      title: '스트레칭',
-      isCompleted: [true, true, false, false, true, false, false],
-    },
-    {
-      title: '사이드 프로젝트',
-      isCompleted: [false, true, false, true, false, false, true],
-    },
-    {
-      title: '물 2L 마시기',
-      isCompleted: [false, true, false, true, false, false, true],
-    },
-  ];
+const HabitTable = ({ id }) => {
+  const [habits, setHabits] = useState([]);
+
+  const fetchData = async () => {
+    const data = await getWeeklyHabits(id);
+
+    setHabits(data);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  // const datas = [
+  //   {
+  //     title: '미라클모닝 6시 기상',
+  //     isCompleted: [true, true, false, true, false, false, false],
+  //   },
+  //   {
+  //     title: '아침 챙겨 먹기',
+  //     isCompleted: [true, true, false, true, false, false, true],
+  //   },
+  //   {
+  //     title: 'React 스터디 책 1챕터 읽기',
+  //     isCompleted: [false, true, false, true, false, true, false],
+  //   },
+  //   {
+  //     title: '스트레칭',
+  //     isCompleted: [true, true, false, false, true, false, false],
+  //   },
+  //   {
+  //     title: '사이드 프로젝트',
+  //     isCompleted: [false, true, false, true, false, false, true],
+  //   },
+  //   {
+  //     title: '물 2L 마시기',
+  //     isCompleted: [false, true, false, true, false, false, true],
+  //   },
+  // ];
 
   return (
     <>
-      {datas.length === 0 ? (
+      {habits.length === 0 ? (
         <p className={styles.emptyTable}>
           아직 습관이 없어요
           <br />
@@ -52,7 +66,7 @@ const HabitTable = () => {
             </tr>
           </thead>
           <tbody>
-            <HabitItems datas={datas} />
+            <HabitItems datas={habits} />
           </tbody>
         </table>
       )}

--- a/src/components/StudyDetailComponents/HabitTable/HabitTable.jsx
+++ b/src/components/StudyDetailComponents/HabitTable/HabitTable.jsx
@@ -16,33 +16,6 @@ const HabitTable = ({ id }) => {
     fetchData();
   }, []);
 
-  // const datas = [
-  //   {
-  //     title: '미라클모닝 6시 기상',
-  //     isCompleted: [true, true, false, true, false, false, false],
-  //   },
-  //   {
-  //     title: '아침 챙겨 먹기',
-  //     isCompleted: [true, true, false, true, false, false, true],
-  //   },
-  //   {
-  //     title: 'React 스터디 책 1챕터 읽기',
-  //     isCompleted: [false, true, false, true, false, true, false],
-  //   },
-  //   {
-  //     title: '스트레칭',
-  //     isCompleted: [true, true, false, false, true, false, false],
-  //   },
-  //   {
-  //     title: '사이드 프로젝트',
-  //     isCompleted: [false, true, false, true, false, false, true],
-  //   },
-  //   {
-  //     title: '물 2L 마시기',
-  //     isCompleted: [false, true, false, true, false, false, true],
-  //   },
-  // ];
-
   return (
     <>
       {habits.length === 0 ? (

--- a/src/components/StudyDetailComponents/Interaction/Interaction.jsx
+++ b/src/components/StudyDetailComponents/Interaction/Interaction.jsx
@@ -1,20 +1,31 @@
+import { useState } from 'react';
 import styles from './Interaction.module.css';
 
-const Interaction = ({ onClick }) => {
+import Toast from '../../Toast/Toast';
+
+const Interaction = ({ onClick, onShare }) => {
   return (
-    <ul className={styles.interContainer}>
-      <li className={styles.greenText}>
-        <button>공유하기</button>
-      </li>
-      <li className={styles.greenText}>|</li>
-      <li className={styles.greenText}>
-        <button onClick={() => onClick('edit')}>수정하기</button>
-      </li>
-      <li className={styles.grayText}>|</li>
-      <li className={styles.grayText}>
-        <button onClick={() => onClick('delete')}>스터디 삭제하기</button>
-      </li>
-    </ul>
+    <>
+      <ul className={styles.interContainer}>
+        <li>
+          <button className={styles.greenText} onClick={() => onShare()}>
+            공유하기
+          </button>
+        </li>
+        <li className={styles.greenText}>|</li>
+        <li>
+          <button className={styles.greenText} onClick={() => onClick('edit')}>
+            수정하기
+          </button>
+        </li>
+        <li className={styles.grayText}>|</li>
+        <li>
+          <button className={styles.grayText} onClick={() => onClick('delete')}>
+            스터디 삭제하기
+          </button>
+        </li>
+      </ul>
+    </>
   );
 };
 

--- a/src/components/StudyDetailComponents/Interaction/Interaction.module.css
+++ b/src/components/StudyDetailComponents/Interaction/Interaction.module.css
@@ -14,6 +14,11 @@
   color: var(--gray_818181);
 }
 
+.toastMiddle {
+  display: flex;
+  justify-content: center;
+}
+
 @media (max-width: 768px) {
   .greenText,
   .grayText {

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -4,6 +4,7 @@ import HabitTable from '../../components/StudyDetailComponents/HabitTable/HabitT
 import Emojis from '../../components/StudyDetailComponents/Emoji/EmojiContainer';
 import Interaction from '../../components/StudyDetailComponents/Interaction/Interaction';
 import StudyDetail from '../../components/StudyDetailComponents/StudyDetail/StudyDetail';
+import ModalLayout from '../../components/Modal/ModalLayout';
 
 import PasswordModal from '../../components/Modal/PasswordModal/PasswordModal';
 import PasswordInput from '../../components/input/PasswordInput';
@@ -13,6 +14,10 @@ import Toast from '../../components/Toast/Toast';
 
 import styles from './StudyDetailPage.module.css';
 import { useNavigate, useParams } from 'react-router-dom';
+import {
+  deleteStudy,
+  validatePassword,
+} from '../../services/StudyDetailService.js';
 
 const StudyDetailPage = () => {
   const navigate = useNavigate();
@@ -23,8 +28,13 @@ const StudyDetailPage = () => {
   const [crtPassword, setCrtPassword] = useState('');
   const [password, setPassword] = useState('');
 
+  const [toastMsg, setToastMsg] = useState('');
+  const [toastType, setToastType] = useState('');
+
   const [isOpen, setIsOpen] = useState(false);
-  const [isToast, setToast] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isCompleteOpen, setIsCompleteOpen] = useState(false);
+  const [isToast, setIsToast] = useState(false);
 
   // 수정을 눌렀는지 습관을 눌렀는지 로그를 눌렀는지 . . .
   const modalHandler = (type) => {
@@ -32,6 +42,7 @@ const StudyDetailPage = () => {
     switch (type) {
       case 'delete':
         setBtnTxt('삭제하기');
+        setLink('delete');
         break;
       case 'edit':
         setBtnTxt('수정하러 가기');
@@ -54,25 +65,64 @@ const StudyDetailPage = () => {
     }
   };
 
-  const submitHandler = (e) => {
+  const submitHandler = async (e) => {
     e.preventDefault();
 
-    if (password !== crtPassword) {
-      // toast ui 튀어나오기
-      setToast(true);
+    const data = await validatePassword(id, password);
+    const isCorrect = data.correct;
 
-      setTimeout(() => setToast(false), 3000);
+    if (!isCorrect) {
+      // toast ui 튀어나오기
+
+      setToastMsg('비밀번호가 일치하지 않습니다. 다시 입력해주세요.');
+      setToastType('error');
+
+      setIsToast(true);
+
+      setTimeout(() => setIsToast(false), 3000);
+      return;
+    }
+
+    if (link === 'delete') {
+      setIsOpen(false);
+      setIsDeleteOpen(true);
       return;
     }
 
     navigate(link);
   };
 
+  const shareHandler = () => {
+    const currentUrl = window.location.href;
+    navigator.clipboard.writeText(currentUrl);
+
+    setToastMsg('링크가 복사되었습니다!');
+    setToastType('success');
+
+    if (isToast) {
+      setIsToast(false);
+    }
+
+    setIsToast(true);
+
+    setTimeout(() => setIsToast(false), 3000);
+  };
+
+  const deleteHandler = async (e) => {
+    e.preventDefault();
+
+    setIsDeleteOpen(false);
+
+    const data = await deleteStudy(id);
+
+    setIsCompleteOpen(true);
+  };
+
   return (
     <div className="wrapper">
       <div className={styles.ixWrapper}>
         <Emojis />
-        <Interaction onClick={modalHandler} />
+        <Interaction onClick={modalHandler} onShare={shareHandler} />
       </div>
 
       <div className={styles.introWrapper}>
@@ -111,12 +161,48 @@ const StudyDetailPage = () => {
         </PasswordModal>
       )}
 
+      {isDeleteOpen && (
+        <ModalLayout>
+          <div className={styles.modalMsgBox}>
+            <p>정말 삭제하시겠습니까?</p>
+          </div>
+          <div className={styles.modalBtnBox}>
+            <Button
+              btnTxt={'취소'}
+              btnStyle="btnCancel"
+              btnType={'button'}
+              onClick={() => setIsDeleteOpen(false)}
+            />
+            <Button
+              btnTxt={'확인'}
+              btnStyle="btnModification"
+              btnType={'button'}
+              onClick={(e) => deleteHandler(e)}
+            />
+          </div>
+        </ModalLayout>
+      )}
+
+      {isCompleteOpen && (
+        <ModalLayout>
+          <div className={styles.modalMsgBox}>
+            <p>삭제가 완료되었습니다.</p>
+          </div>
+          <div className={styles.modalBtnBox}>
+            <Button
+              btnTxt={'홈으로'}
+              btnStyle="btnDefault"
+              btnType={'button'}
+              onClick={() => navigate('/')}
+            />
+          </div>
+        </ModalLayout>
+      )}
+
       {isToast && (
-        <Toast
-          toastType="error"
-          toastMsg="비밀번호가 일치하지 않습니다. 다시 입력해주세요."
-          toastStyle="L"
-        />
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <Toast toastType={toastType} toastMsg={toastMsg} />
+        </div>
       )}
     </div>
   );

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -136,7 +136,7 @@ const StudyDetailPage = () => {
       <main className={styles.innerWrapper}>
         <h2 className={styles.tableTitle}>습관 기록표</h2>
 
-        <HabitTable />
+        <HabitTable id={id} />
       </main>
 
       {isOpen && (

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -86,6 +86,7 @@ const StudyDetailPage = () => {
     if (link === 'delete') {
       setIsOpen(false);
       setIsDeleteOpen(true);
+      setPassword('');
       return;
     }
 
@@ -141,7 +142,10 @@ const StudyDetailPage = () => {
 
       {isOpen && (
         <PasswordModal
-          onClose={() => setIsOpen(false)}
+          onClose={() => {
+            setIsOpen(false);
+            setPassword('');
+          }}
           title={'연우의 개발공장'}
         >
           <form>

--- a/src/pages/StudyDetailPage/StudyDetailPage.module.css
+++ b/src/pages/StudyDetailPage/StudyDetailPage.module.css
@@ -47,6 +47,24 @@
   font-weight: 600;
 }
 
+.modalMsgBox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  min-height: 150px;
+
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.modalBtnBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+}
+
 @media (max-width: 1024px) {
 }
 

--- a/src/services/StudyDetailService.js
+++ b/src/services/StudyDetailService.js
@@ -1,5 +1,6 @@
 const STUDY_API_URL = 'http://localhost:8080/api/studies';
 const EMOJI_API_URL = 'http://localhost:8080/api/emojis';
+const HABIT_API_URL = 'http://localhost:8080/api/habits';
 
 export const getStudyDetail = async (id) => {
   const res = await fetch(`${STUDY_API_URL}/${id}`);
@@ -65,4 +66,27 @@ export const updateEmojis = async (id, emojiId) => {
   const data = await res.json();
 
   return data.data;
+};
+
+export const getWeeklyHabits = async (id) => {
+  const res = await fetch(`${HABIT_API_URL}/${id}/weekly`);
+  const data = await res.json();
+
+  const habits = data.data.habits;
+
+  const weeklyHabits = habits.map((habit) => {
+    let isCompleted = [false, false, false, false, false, false, false];
+
+    const days = habit.records.forEach((record) => {
+      const date = new Date(record.date);
+      const day = date.getDay() - 1; // date 는 일요일 시작이라 1 빼줌
+
+      isCompleted[day] = record.isCompleted;
+      return;
+    });
+
+    return { title: habit.name, isCompleted };
+  });
+
+  return weeklyHabits;
 };

--- a/src/services/StudyDetailService.js
+++ b/src/services/StudyDetailService.js
@@ -8,6 +8,31 @@ export const getStudyDetail = async (id) => {
   return data.data;
 };
 
+export const validatePassword = async (id, password) => {
+  const res = await fetch(`${STUDY_API_URL}/${id}/pw`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      password,
+    }),
+  });
+
+  const data = await res.json();
+
+  return data.data;
+};
+
+export const deleteStudy = async (id) => {
+  const res = await fetch(`${STUDY_API_URL}/${id}`, {
+    method: 'DELETE',
+  });
+  const data = res.json();
+
+  return data.data;
+};
+
 // emoji
 export const getEmojis = async (id) => {
   const res = await fetch(`${EMOJI_API_URL}/${id}`);


### PR DESCRIPTION
## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 2주차
- **PR 요약**: 구현한 기능 혹은 해당 PR의 내용을 요약

공유하기 버튼을 누를 시 클립보드로  해당 페이지 URL을 복사하게끔 하였습니다.
삭제버튼 flow를 적용했습니다.
주간 습관을 조회할 수 있도록 하였습니다.

---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 공유하기를 누르면 "링크가 복사되었습니다!" 라는 toast 메시지가 뜨면서 해당 페이지 URL 을 클립보드로 복사합니다.
<img width="1258" height="1101" alt="image" src="https://github.com/user-attachments/assets/7f4b26b4-66f7-4bf1-9813-08cdf14abc0d" />

- 삭제를 누를 시 비밀번호 모달을 보여줍니다.
- 비밀번호가 일치하면 "정말로 삭제하시겠습니까?" 라는 모달이 보여줍니다.
- 삭제를 누르면 "삭제가 완료되었습니다." 라는 모달을 보여줍니다.
- 확인을 누를 시 홈페이지로 돌아갑니다.
<img width="1261" height="1060" alt="image" src="https://github.com/user-attachments/assets/d53a84c4-5bf3-47bd-9f58-c95956f3d9c5" />


- 습관 기록표를 조회할 수 있습니다.
<img width="1246" height="1062" alt="image" src="https://github.com/user-attachments/assets/83d2b55b-804f-4b70-b79a-c0c2de067ddb" />

---

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **파일/위치**: `‎src/pages/StudyDetailPage/StudyDetailPage.jsx` (143번째 줄 이후~)
- **요청 내용**:
  > 현재 StudyDetailPage에는 세 가지의 modal이 존재해야합니다.
1. 비밀번호 확인 modal
2. 정말 삭제할건지 재확인하는 modal
3. 삭제가 완료되었다는 modal

현재는 state로 각각의 is{delete or completed or password}Open 값을 state로 저장하고 원할 때 false, true 하면서 나타내고 있는데, 이 방식을 어떻게 하면 더 좋게 바꿀 수 있는 지 궁금합니다.
- **고민한 점**:
 > isOpen 관련 custom hook 을 만들어 사용하는게 좋을까 고민을 해봤었습니다.


### 요청 2
- **파일/위치**: `‎src/pages/StudyDetailPage/StudyDetailPage.jsx` (143번째 줄 이후~)
- **요청 내용**:
  > 현재 StudyDetailPage에는 toast UI 가 존재합니다.
해당 toast UI 는 공통 컴포넌트로 'error'인지 'success' 인지에 따라 스타일이 달라집니다.
StudyDetailPage에서는 "비밀번호가 틀렸다"고 보여주는 error toast 와 공유하기 버튼을 눌렀을 때 "링크가 복사되었습니다!" 를 보여주는 success toast가 존재합니다.

이것도 위의 모달들과 마찬가지로 setIsToast 를 함수 내에서 true, false 값으로 확인하여 보여주고 아니고를 판단하는데, 공유하기를 클릭 후 비밀번호 모달에서 비밀번호를 틀리면 toast ui 내부값은 바뀌지만 true, false 타이밍은 같이 갖고 있기 때문에 생성이 언제되었든간에 다시 false 가 됩니다.

해당 토스트가 따로 보여주게끔..? 생성되게끔 하기 위해선 어떤 방법이 가능할까요?

(비밀번호를 여러번 틀렸을 때에도 마찬가지입니다..! 언제 틀렸든 간에 함수 내에서 정의한 3초 뒤 종료 프로세스를 무조건 따르고 있습니다.)

- **고민한 점**:
 > toast UI 관련 라이브러리를 써야하나 하는 고민을 해봤었습니다.. 하지만 이미 공통 컴포넌트를 만든 상태에서 라이브러리를 또 두게되면 애매할 것 같았습니다.. 

해당 컴포넌트를 실행되어야 할 때만 create 해주고 일정 개수 이상 생성되지 못하게 두고.. 그 개수 이상 생성될 시 먼저 나온 toast들을 지우는 방식의 custom hook 을 만들어두면 좋을까요?

### 요청3
- **파일/위치**: `src/services/StudyDetailService.js`
- **요청 내용**:
 > 현재 서버 쪽에서 weekly로 뿌려지는 record 값을 가져와서 주간 (월 ~ 일) 에 해당 작업이 완료되어있는가 아닌가를 보여주어야 합니다. 
 서버쪽에서 weekly 데이터를 받아와 `getWeeklyHabits` 함수에서 `let isCompleted = [false, false, false, false, false, false, false];` 같은 형식으로 월 ~ 일의 임시(초기?) 데이터를 지정한 후 해당 habit의 records를 돌면서 .getDay()에 맞는 값에 isCompleted를 다시 저장하는 형식으로 구현해둔 상태입니다.

- **고민한 점**:
 >지정한 값(하드코딩..?) 을 두지 않고 할 수 있는 방법이 있을지 고민입니다.
항상 월 ~ 일 데이터는 가지고 있어야하는데, records 값이 만약 수요일부터 만들어져 있을 시 수요일부터의 값만 넘기기 때문에 지정해두지 않고 앞 요일을 판단할 수 있는 기준을 모르겠습니다..
