### PR TITLE
[Feat] 날짜 이동 및 해당 날짜 리스트 조회 기능 구현 / 컴포넌트 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ const App = () => {
           {/* 홈페이지는 <Route index element={<페이지 컴포넌트 />} /> 로 추가하기 */}
           {/* 각 페이지 <Route path="url" element={<페이지 컴포넌트 />} /> 로 추가하기 */}
           <Route path=":id/focus" element={<TodayFocus />} />
-          <Route path=":id/logs" element={<LogPage />} />
+          <Route path="/:studyId/logs" element={<LogPage />} />
           <Route path=":id/detail" element={<StudyDetailPage />} />
           <Route path=":id/habit" element={<TodayHabitPage />} />
           <Route path="/create" element={<StudyCreate />} />

--- a/src/assets/icons/ic_arrow_left_big.svg
+++ b/src/assets/icons/ic_arrow_left_big.svg
@@ -1,0 +1,4 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="49" height="49" rx="24.5" fill="white" stroke="#DDDDDD"/>
+<path d="M27.9993 33.1143L18.092 24.9997L28.1834 17.1153" stroke="#818181" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/ic_arrow_right_big.svg
+++ b/src/assets/icons/ic_arrow_right_big.svg
@@ -1,0 +1,4 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="49" height="49" rx="24.5" fill="white" stroke="#DDDDDD"/>
+<path d="M22 17L32 25L22 33" stroke="#818181" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/LogPage/LogDateSelector.jsx
+++ b/src/pages/LogPage/LogDateSelector.jsx
@@ -1,0 +1,52 @@
+import styles from "./LogPage.module.css";
+import arrowLeft from '../../assets/icons/ic_arrow_left_big.svg';
+import arrowRight from '../../assets/icons/ic_arrow_right_big.svg';
+
+const LogDateSelector = ({ date, setDate, formatDate }) => {
+  
+  const isToday = () => {
+    const today = new Date().toLocaleDateString();
+    const selectedDate = date.toLocaleDateString();
+
+    return today === selectedDate;
+  }
+
+
+    const prevDateHandler = () => {
+      const newDate = new Date(date);
+      newDate.setDate(newDate.getDate() - 1);
+      setDate(newDate);
+    }
+  
+    const nextDateHandler = () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+  
+      if (date >= today) {
+        return;
+      }
+  
+      const newDate = new Date(date);
+  
+      newDate.setDate(newDate.getDate() + 1);
+      setDate(newDate);
+    }
+
+  return (
+    <div className={styles.dateSelectorContainer}>
+      <button onClick={prevDateHandler}>
+        <img alt="이전 날짜" src={arrowLeft}/>
+      </button>
+      <span className={styles.nowDate}>
+        {formatDate(date)}
+      </span>
+      <button 
+        onClick={nextDateHandler}
+        style={{ visibility: isToday() ? "hidden" : "visible"}}>
+        <img alt="다음 날짜" src={arrowRight}/>
+      </button>
+    </div>
+  );
+};
+
+export default LogDateSelector;

--- a/src/pages/LogPage/LogHeader.jsx
+++ b/src/pages/LogPage/LogHeader.jsx
@@ -1,0 +1,64 @@
+import styles from "./LogPage.module.css";
+import LinkButton from '../../components/LinkButton/LinkButton';
+import CurrentTime from '../../components/CurrentTime/CurrentTime';
+
+const LogHeader = ({ studyId, logType, setLogType }) => {
+  return (
+    <div className={styles.topwrapper}>
+        {/** 스터디이름, 링크 */}
+        <div className={styles.top}>
+          <h1 className={styles.title}>
+            연우의 개발공장
+          </h1>
+          <div className={styles.linkContainer}>
+            <LinkButton  
+              className={styles.linkButton}
+              text="스터디" 
+              url={`/${studyId}/detail`}
+            />
+            <LinkButton 
+              className={styles.linkButton}
+              text="홈" 
+              url="/"
+            />
+          </div>
+        </div>
+        
+        <div className={styles.dateWrapper}>
+        {/** 시간, 라디오버튼 */}
+          <div className={styles.timeContainer}>
+            <CurrentTime />
+          </div>
+
+          {/* 라디오 */}
+          <div className={styles.radioBox}>
+            <label 
+              className={`${styles.radioBoxItem} ${
+                logType === "focus" ? styles.active : ""
+              }`}>
+              <input
+                type="radio"
+                value="focus"
+                checked={logType === "focus"}
+                onChange={(e) => setLogType(e.target.value)}
+              />
+              집중 시간
+            </label>
+            <label className={`${styles.radioBoxItem} ${
+              logType === "point" ? styles.active : ""
+            }`}>
+              <input 
+                type="radio"
+                value="point"
+                checked={logType === "point"}
+                onChange={(e) => setLogType(e.target.value)}
+              />
+              포인트
+            </label>
+          </div>       
+        </div>
+      </div>
+  );
+};
+
+export default LogHeader;

--- a/src/pages/LogPage/LogList.jsx
+++ b/src/pages/LogPage/LogList.jsx
@@ -1,0 +1,84 @@
+import styles from "./LogPage.module.css";
+import { formattedTime } from '../../utils/formattedTime';
+
+const LogList = ({ logType, pointLogs, focusLogs }) => {
+
+
+  const logList = logType === "point" ? pointLogs : focusLogs;
+  const hasData = logList && logList.length > 0;
+
+
+  const dailyTotal = { point: 0, focus: 0 };
+
+  (pointLogs || []).forEach(log => {
+    dailyTotal.point += (log.points || 0);
+  });
+
+  (focusLogs || []).forEach(log => {
+    dailyTotal.focus += (Number(log.focusDuration) || 0);
+  });
+
+  return (
+    <>
+      {/* 총합 */}
+      {hasData && (
+        <div className={styles.totalBox}>
+          <h3 className={styles.logType}>
+            {logType === "point" ? "총 획득 포인트" : "총 집중 시간"}
+          </h3>
+
+          {logType === "point" ? (
+            <h3 className={styles.totalPointValue}>
+              {(dailyTotal.point).toLocaleString()} P
+            </h3>
+          ) : (
+            <h3 className={styles.totalFocusValue}>
+              {formattedTime(dailyTotal.focus)}
+            </h3>
+          )}
+        </div>
+      )}
+
+      {/* 리스트 */}
+        <div className={styles.list}>
+          {hasData ? (
+            logList.map((item) => (
+            <div
+              key={item.id || item.createdAt}
+
+              className={styles.row}
+            >
+              {logType === "point" ? (
+                <>
+                  <span className={styles.rowDate}>
+                    {item.createdAt}
+                  </span>
+                  <span className={styles.rowValue}>
+                    {item.points} P
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className={styles.rowDate}>
+                    {item.createdAt}
+                  </span>
+                  <span className={styles.rowValue}>
+                    {formattedTime(item.focusDuration)}
+                  </span>
+                </>
+              )}
+            </div>
+          ))
+          ) : (
+            <>
+              <p className={styles.noData}>
+                불러올 기록이 없어요.
+              </p>
+            </>
+          )}
+        </div>
+    </>
+  );
+};
+
+export default LogList;

--- a/src/pages/LogPage/LogList.jsx
+++ b/src/pages/LogPage/LogList.jsx
@@ -45,7 +45,6 @@ const LogList = ({ logType, pointLogs, focusLogs }) => {
             logList.map((item) => (
             <div
               key={item.id || item.createdAt}
-
               className={styles.row}
             >
               {logType === "point" ? (
@@ -72,7 +71,7 @@ const LogList = ({ logType, pointLogs, focusLogs }) => {
           ) : (
             <>
               <p className={styles.noData}>
-                불러올 기록이 없어요.
+                해당 날짜의 기록이 없어요.
               </p>
             </>
           )}

--- a/src/pages/LogPage/LogPage.jsx
+++ b/src/pages/LogPage/LogPage.jsx
@@ -1,26 +1,17 @@
 import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import styles from "./LogPage.module.css";
-import LinkButton from '../../components/LinkButton/LinkButton';
-import CurrentTime from '../../components/CurrentTime/CurrentTime';
-import { formattedTime } from '../../utils/formattedTime';
-import arrowLeft from '../../assets/icons/ic_arrow_left_big.svg';
-import arrowRight from '../../assets/icons/ic_arrow_right_big.svg';
+import LogHeader from './LogHeader';
+import LogDateSelector from './LogDateSelector';
+import LogList from './LogList';
 
 
 const Logs = () => {
-  const studyId = 5;
-
+  const { studyId } = useParams();
   const [logType, setLogType] = useState("focus");
   const [date, setDate] = useState(new Date());
   const [pointLogs, setPointLogs] = useState([]);
   const [focusLogs, setFocusLogs] = useState([]);
-
-  const totalPoints = (pointLogs || []).reduce((acc, cur) => {
-    return acc + (cur.points || 0);
-  }, 0);
-  const totalFocus = (focusLogs || []).reduce((acc, cur) => {
-    return acc + (cur.focusDuration || 0);
-  }, 0);
 
   const formatDate = (date) => {
     const year = date.getFullYear();
@@ -30,167 +21,40 @@ const Logs = () => {
     return `${year}-${month}-${day}`;
   }
 
-  const prevDateHandler = () => {
-    const newDate = new Date(date);
-    newDate.setDate(newDate.getDate() - 1);
-    setDate(newDate);
-  }
-
-  const nextDateHandler = () => {
-    const newDate = new Date(date);
-    newDate.setDate(newDate.getDate() + 1);
-    setDate(newDate);
-  }
-
   useEffect(() => {
     const fetchData = async () => {
       const formattedDate = formatDate(date);
-        const res = await fetch(`http://localhost:8080/api/logs/${studyId}/pointLogs?date=${formattedDate}`);
+        const res = await fetch(`http://localhost:8080/api/logs/${studyId}/logs?date=${formattedDate}`);
         const data = await res.json();
 
         setPointLogs(data.data || []);
         setFocusLogs(data.data || []);
       } 
     fetchData();
-  }, [date]);
+  }, [date, studyId]);
 
-  const logList = logType === "point" ? pointLogs : focusLogs;
 
   return (
     // 페이지 전체 컨테이너
     <div className="wrapper">
-      
-      {/** top */}
-      <div className={styles.topwrapper}>
-        {/** 스터디이름, 링크 */}
-        <div className={styles.top}>
-          <h1 className={styles.title}>
-            연우의 개발공장
-          </h1>
-          <div className={styles.linkContainer}>
-            <LinkButton  
-              className={styles.linkButton}
-              text="스터디" 
-              url="/:id/detail"
-            />
-            <LinkButton 
-              className={styles.linkButton}
-              text="홈" 
-              url="/:id/detail"
-            />
-          </div>
-        </div>
-        
-        <div className={styles.dateWrapper}>
-        {/** 시간, 라디오버튼 */}
-          <div className={styles.timeContainer}>
-            <CurrentTime />
-          </div>
-
-          {/* 라디오 */}
-          <div className={styles.radioBox}>
-            <label 
-              className={`${styles.radioBoxItem} ${
-                logType === "focus" ? styles.active : ""
-              }`}>
-              <input
-                type="radio"
-                value="focus"
-                checked={logType === "focus"}
-                onChange={(e) => setLogType(e.target.value)}
-              />
-              집중 시간
-            </label>
-            <label className={`${styles.radioBoxItem} ${
-              logType === "point" ? styles.active : ""
-            }`}>
-              <input 
-                type="radio"
-                value="point"
-                checked={logType === "point"}
-                onChange={(e) => setLogType(e.target.value)}
-              />
-              포인트
-            </label>
-          </div>       
-        </div>
-
-      </div>
-
-      
-
-
+      <LogHeader 
+        studyId={studyId}
+        logType={logType}
+        setLogType={setLogType}
+      />
       <div className={styles.logWrapper}>
-        <div className={styles.dateSelectorContainer}>
-          <button onClick={prevDateHandler}>
-            <img alt="이전 날짜" src={arrowLeft}/>
-          </button>
-          <span className={styles.nowDate}>
-            {formatDate(date)}
-          </span>
-          <button onClick={nextDateHandler}>
-            <img alt="다음 날짜" src={arrowRight}/>
-          </button>
-        </div>
-
-        {/* 총합 */}
-        <div className={styles.totalBox}>
-          <h3 className={styles.logType}>
-            {logType === "point" ? "총 획득 포인트" : "총 집중 시간"}
-          </h3>
-
-          {logType === "point" ? (
-            <h3 className={styles.totalPointValue}>
-              {totalPoints.toLocaleString()} P
-            </h3>
-          ) : (
-            <h3 className={styles.totalFocusValue}>
-              {formattedTime(totalFocus)}
-            </h3>
-          )}
-  
-        </div>
-
-      
-        {/* 로그 리스트 */}
-        <div className={styles.list}>
-          {logList && logList.length > 0 ? (
-            logList.map((item) => (
-            <div
-              key={item.id || item.createdAt}
-
-              className={styles.row}
-            >
-              {logType === "point" ? (
-                <>
-                  <span className={styles.rowDate}>
-                    {item.createdAt}
-                  </span>
-                  <span className={styles.rowValue}>
-                    {item.points} P
-                  </span>
-                </>
-              ) : (
-                <>
-                  <span className={styles.rowDate}>
-                    {item.createdAt}
-                  </span>
-                  <span className={styles.rowValue}>
-                    {formattedTime(item.focusDuration)}
-                  </span>
-                </>
-              )}
-            </div>
-          ))
-          ) : (
-            <>
-              <p className={styles.noData}>
-                불러올 기록이 없어요.
-              </p>
-            </>
-          )}
-        </div>
+        <LogDateSelector 
+          date={date}
+          setDate={setDate}
+          formatDate={formatDate}
+        />
+        <LogList 
+          logType={logType}
+          pointLogs={pointLogs}
+          focusLogs={focusLogs}
+        />
       </div>
+      
     </div>
   );
 };

--- a/src/pages/LogPage/LogPage.jsx
+++ b/src/pages/LogPage/LogPage.jsx
@@ -3,11 +3,13 @@ import styles from "./LogPage.module.css";
 import LinkButton from '../../components/LinkButton/LinkButton';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 import { formattedTime } from '../../utils/formattedTime';
+import arrowLeft from '../../assets/icons/ic_arrow_left_big.svg';
+import arrowRight from '../../assets/icons/ic_arrow_right_big.svg';
 
 
 const Logs = () => {
-  const studyId = 1; // 임시값
-  
+  const studyId = 5;
+
   const [logType, setLogType] = useState("focus");
   const [date, setDate] = useState(new Date());
   const [pointLogs, setPointLogs] = useState([]);
@@ -28,30 +30,29 @@ const Logs = () => {
     return `${year}-${month}-${day}`;
   }
 
+  const prevDateHandler = () => {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() - 1);
+    setDate(newDate);
+  }
+
+  const nextDateHandler = () => {
+    const newDate = new Date(date);
+    newDate.setDate(newDate.getDate() + 1);
+    setDate(newDate);
+  }
+
   useEffect(() => {
     const fetchData = async () => {
       const formattedDate = formatDate(date);
-      try {
-        const pointRes = await fetch(`http://localhost:8080/api/logs/${studyId}/pointLogs?date=${formattedDate}`);
-        const focusRes = await fetch(`http://localhost:8080/api/logs/${studyId}/focusLogs?date=${formattedDate}`);
-        
-        if (!pointRes.ok || !focusRes.ok) {
-          throw new Error("API 호출 실패");
-        }
+        const res = await fetch(`http://localhost:8080/api/logs/${studyId}/pointLogs?date=${formattedDate}`);
+        const data = await res.json();
 
-        const pointData = await pointRes.json();
-        const focusData = await focusRes.json();
-
-        setPointLogs(pointData.data || []);
-        setFocusLogs(focusData.data || []);
-      } catch (error) {
-        console.error("데이터 로딩 실패:", error);
-        setPointLogs([]);
-        setFocusLogs([]);
-      }
-    } 
+        setPointLogs(data.data || []);
+        setFocusLogs(data.data || []);
+      } 
     fetchData();
-  }, [date])
+  }, [date]);
 
   const logList = logType === "point" ? pointLogs : focusLogs;
 
@@ -63,7 +64,9 @@ const Logs = () => {
       <div className={styles.topwrapper}>
         {/** 스터디이름, 링크 */}
         <div className={styles.top}>
-          <h1 className={styles.title}>연우의 개발공장</h1>
+          <h1 className={styles.title}>
+            연우의 개발공장
+          </h1>
           <div className={styles.linkContainer}>
             <LinkButton  
               className={styles.linkButton}
@@ -114,8 +117,22 @@ const Logs = () => {
 
       </div>
 
+      
+
 
       <div className={styles.logWrapper}>
+        <div className={styles.dateSelectorContainer}>
+          <button onClick={prevDateHandler}>
+            <img alt="이전 날짜" src={arrowLeft}/>
+          </button>
+          <span className={styles.nowDate}>
+            {formatDate(date)}
+          </span>
+          <button onClick={nextDateHandler}>
+            <img alt="다음 날짜" src={arrowRight}/>
+          </button>
+        </div>
+
         {/* 총합 */}
         <div className={styles.totalBox}>
           <h3 className={styles.logType}>
@@ -123,15 +140,15 @@ const Logs = () => {
           </h3>
 
           {logType === "point" ? (
-            <h3 className={styles.totalValue}>{totalPoints.toLocaleString()} P</h3>
-            
+            <h3 className={styles.totalPointValue}>
+              {totalPoints.toLocaleString()} P
+            </h3>
           ) : (
-            <h3 className={styles.totalValue}>
+            <h3 className={styles.totalFocusValue}>
               {formattedTime(totalFocus)}
             </h3>
           )}
-          
-          
+  
         </div>
 
       
@@ -146,19 +163,31 @@ const Logs = () => {
             >
               {logType === "point" ? (
                 <>
-                  <span className={styles.rowDate}>{item.createdAt}</span>
-                  <span className={styles.rowValue}>{item.points} P</span>
+                  <span className={styles.rowDate}>
+                    {item.createdAt}
+                  </span>
+                  <span className={styles.rowValue}>
+                    {item.points} P
+                  </span>
                 </>
               ) : (
                 <>
-                  <span className={styles.rowDate}>{item.createdAt}</span>
-                  <span className={styles.rowValue}>{formattedTime(item.focusDuration)}</span>
+                  <span className={styles.rowDate}>
+                    {item.createdAt}
+                  </span>
+                  <span className={styles.rowValue}>
+                    {formattedTime(item.focusDuration)}
+                  </span>
                 </>
               )}
             </div>
           ))
           ) : (
-            <div className={styles.noData}>기록이 없습니다.</div>
+            <>
+              <p className={styles.noData}>
+                불러올 기록이 없어요.
+              </p>
+            </>
           )}
         </div>
       </div>

--- a/src/pages/LogPage/LogPage.module.css
+++ b/src/pages/LogPage/LogPage.module.css
@@ -145,7 +145,7 @@
 }
 
 .rowValue {
-  color: var(--black_414141);
+  color: var(--green_text_578246);
   font-size: 16px;
 }
 

--- a/src/pages/LogPage/LogPage.module.css
+++ b/src/pages/LogPage/LogPage.module.css
@@ -36,6 +36,7 @@
   margin-top: 4px;
 }
 
+/* 집중 시간, 포인트 */
 .radioBox {
   display: flex;
   justify-content: end;
@@ -68,11 +69,25 @@
   border: none;
 }
 
+/* 날짜 이동 컨테이너 */
+.dateSelectorContainer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.nowDate {
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--gray_818181);
+}
+
 .totalBox {
   display: flex;
   justify-content: center;
   align-content: center;
-  margin-bottom: 30px;
+  margin: 30px;
   gap: 20px;
   font-size: 20px;
 }
@@ -83,13 +98,19 @@
   font-weight: 800;
 }
 
-.totalValue {
+.totalFocusValue {
   display: flex;
   justify-content: center;
   align-items: center;
-  color: var(--green_text_578246);
+  color: var(--red_F50E0E);
 }
 
+.totalPointValue {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--blue_text_418099);
+}
 
 .logWrapper {
   border-radius: 20px;
@@ -126,6 +147,11 @@
 .rowValue {
   color: var(--black_414141);
   font-size: 16px;
+}
+
+.noData {
+  padding: 100px;
+  color: var(--gray_818181);
 }
 
 @media (max-width: 1024px) {

--- a/src/pages/LogPage/LogPage.module.css
+++ b/src/pages/LogPage/LogPage.module.css
@@ -150,7 +150,7 @@
 }
 
 .noData {
-  padding: 100px;
+  margin-top: 100px;
   color: var(--gray_818181);
 }
 


### PR DESCRIPTION
## 🔥 Related Issues

- close #82 
- close #83 


## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 11주차
- **PR 요약**: 컴포넌트 분리와 날짜 이동 및 조회 기능을 구현했습니다.

---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

- App.jsx의 라우터 경로를 수정했습니다.
- 컴포넌트를 분리하였습니다.
- 리스트 컨테이너의 양쪽 버튼 클릭 시 조회된 날짜의 이전 날짜와 다음 날짜의 리스트를 조회할 수 있습니다.
- 오늘을 조회했을 경우 내일을 조회하는 버튼은 보이지 않습니다.
- hasdata를 통해 빈 값이 들어올 경우 "해당 날짜의 기록이 없어요."를 출력합니다.
- 조회된 해당 날짜의 총 획득 포인트와 총 집중시간을 합산하여 출력합니다. (dailyTotal)


---


## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- **집중시간**
<img width="1177" height="637" alt="image" src="https://github.com/user-attachments/assets/d4ab4617-4a65-4983-8a23-6d1ae5fd2cef" />


- **포인트**
<img width="1180" height="601" alt="image" src="https://github.com/user-attachments/assets/782a6bf0-aaa3-4588-9c54-6df3ed8cb583" />


- **기록이 없는 날**
<img width="1166" height="623" alt="image" src="https://github.com/user-attachments/assets/57ba87bf-d9b1-43e1-acd3-04169a3beba0" />


---


## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

- 생성시간이 UTC로 설정되어 조회 시 날짜가 맞지 않는 경우가 있습니다. 백엔드에서 수정이 필요할 듯합니다. 
- (백엔드에서 타임존 오프셋(+09:00) 처리하기)
- +++ 더 찾아보니 백엔드는 UTC를 사용하는 것이 맞다 생각되어 프론트에서 수정하겠습니다.!


---


## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **파일/위치**: src/pages/LogPage/LogList.jsx
- **요청 내용**: 리스트를 불러오는 데에 시간이 좀 걸리는데, 어떻게 하면 더 빨리 불러올 수 있는지 궁금합니다.
- **고민한 점**: 총 획득포인트와 총 집중시간 계산 시 reduce를 사용했어야하는데 forEach를 써서 더 오래 걸리는 것 같습니다.. / 총 합계 부분 텍스트는 리스트 조회 전 처음부터 보이게 하고 합계 값은 보이지 않다가 계산 완료 시 보이는게 맞을까요?


### 요청 2
- **파일/위치**: src/components/CurrentTime/CurrentTime.jsx
- **요청 내용**: 4번째 줄의 formatDate에서 year, month, day... 전부 따로 선언하고 값을 넣었는데 이 부분이 좀 더 간략하게 작성될 수 있을까요?
- **고민한 점**: 잘 모르겠습니다..

