### PR TITLE
[Feat] 습관 수정 및 삭제 API 연동 함수 추가

### DIFF
--- a/src/pages/LogPage/LogPage.jsx
+++ b/src/pages/LogPage/LogPage.jsx
@@ -31,24 +31,29 @@ const LogPage = () => {
   return (
     // 페이지 전체 컨테이너
     <div className="wrapper">
+
+      {/** 헤더 */}
       <LogHeader 
         id={id}
         logType={logType}
         setLogType={setLogType}
       />
+
+      {/** 현재 시간, 라디오버튼 */}
       <div className={styles.logWrapper}>
         <LogDateSelector 
           date={date}
           setDate={setDate}
           formatDate={formatDate}
         />
+
+        {/** 로그 리스트 */}
         <LogList 
           logType={logType}
           pointLogs={pointLogs}
           focusLogs={focusLogs}
         />
       </div>
-      
     </div>
   );
 };

--- a/src/services/HabitService.js
+++ b/src/services/HabitService.js
@@ -48,3 +48,43 @@ export const toggleHabit = async (studyId, habitId) => {
 
   return result.data;
 };
+
+
+// 습관 수정
+export const editHabit = async (studyId, habitId, name) => {
+  const response = await fetch(`${API_URL}/api/habits/${studyId}/${habitId}`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({name}),
+    },
+  );
+
+  const result = await response.json();
+
+  if (!response.ok || !result.success) {
+    throw new Error(result.message || '습관 완료 상태 변경을 실패했습니다.');
+  }
+
+  return result.data;
+};
+
+
+// 습관 삭제
+export const deleteHabit = async (studyId, habitId) => {
+  const response = await fetch(`${API_URL}/api/habits/${studyId}/${habitId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+
+  const result = await response.json();
+
+  if (!response.ok || !result.success) {
+    throw new Error(result.message || '습관 삭제를 실패했습니다.');
+  }
+
+  return result.data;
+};


### PR DESCRIPTION
## 🔥 Related Issues

- close #116 

---

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 습관 수정 삭제 API 연동: 습관 수정 및 삭제(종료) 기능을 백엔드와 연결했습니다.
   - 습관 목록 유지를 위해 물리적 삭제가 아닌, soft Delete 방식을 사용했습니다.


---


## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 습관 관리(수정/삭제)를 위한 fetch 서비스 로직을 추가
   - editHabit: 습관명 수정 PATCH 요청 로직을 구현했습니다.
   - deleteHabit: 습관을 리스트에서 제거하는 DELETE 요청 로직을 구현했습니다.
- soft Delete 방식 적용 
   - 사용자 관점에서는 목록에서 삭제된 것으로 인식되지만, DB의 데이터를 직접 삭제하지 않고 endDate를 수정하는 Soft Delete 방식으로 구현했습니다.
- 라우터는 delete라 명시되어있지만 백엔드에선 삭제가 아닌, 버튼이 클릭된 시간(날짜)으로 endDate가 수정됩니다.


---


## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **파일/위치**: `src/services/HabitService.js / deleteHabit`
- **요청 내용**: 현재 내부 로직은 endDate를 수정하는 방식이지만, API 인터페이스는 DELETE를 사용하고 있습니다.
   - 사용자의 관점(의도)에 초점을 맞춘 **DELETE**
   - 데이터 상태에 초점을 맞춘 **PATCH** 
   - 실제 실무 환경에서 soft delete를 처리할 때 어떤 메소드를 더 권장하거나 선호하시는지 멘토님의 의견이 궁금합니다.
- **고민한 점**: 데이터를 제거하지 않는다는 점에서 PATCH가 더 맞을 수 있으나, 프론트엔드와 API 연결을 고려했을 때, 유저의 '삭제' 요청이므로 DELETE가 더 직관적이지 않나 고민했습니다.