### PR TITLE
[Feat] 404 NotFound 에러 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import StudyDetailPage from './pages/StudyDetailPage/StudyDetailPage';
 import TodayHabitPage from './pages/TodayHabitPage/TodayHabitPage';
 import StudyCreate from './pages/CreatePage/StudyCreate';
 import StudyUpdate from './pages/UpdatePage/StudyUpdate';
+import NotFound from './pages/NotFoundPage/NotFound';
 
 const App = () => {
   return (
@@ -26,6 +27,7 @@ const App = () => {
           <Route path=":id/habit" element={<TodayHabitPage />} />
           <Route path=":id/update" element={<StudyUpdate />} />
           <Route path="/create" element={<StudyCreate />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </>

--- a/src/pages/NotFoundPage/NotFound.jsx
+++ b/src/pages/NotFoundPage/NotFound.jsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import styles from './NotFound.module.css';
+
+const NotFound = () => {
+  return (
+    <div className={`wrapper ${styles.notFoundWrapper}`}>
+      <div className={styles.notFoundContainer}>
+        <div className={styles.content}>
+          <h1 className={styles.errCode}>404</h1>
+          <h2>페이지를 찾을 수 없습니다..</h2>
+          <p>요청하신 페이지가 존재하지 않거나 이동되었습니다</p>
+        </div>
+
+        <Link to="/" className={`btn ${styles.homeBtn}`}>
+          홈으로
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/src/pages/NotFoundPage/NotFound.module.css
+++ b/src/pages/NotFoundPage/NotFound.module.css
@@ -1,0 +1,62 @@
+.notFoundWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 75vh;
+  min-height: 400px;
+}
+
+.notFoundContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.content > h2 {
+  font-size: 32px;
+  font-weight: 600;
+}
+.content > p {
+  color: var(--gray_818181);
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.errCode {
+  color: var(--error_C41013);
+  font-size: 50px;
+  font-weight: 900;
+}
+
+.homeBtn {
+  width: fit-content;
+  padding: 15px 30px;
+  border-radius: 20px;
+}
+
+/* 모바일 */
+@media (max-width: 768px) {
+  .errCode {
+    font-size: 36px;
+  }
+
+  .content > h2 {
+    font-size: 24px;
+  }
+  .content > p {
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .homeBtn {
+    padding: 13px 24px;
+    font-size: 14px;
+    border-radius: 15px;
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issues

- close #118 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

존재하지 않는 경로를 처리하기 위한 404 NotFound 에러 페이지를 구현

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 404 페이지 컴포넌트 구현
- 맨 마지막 Route에 `path="*"` 404 페이지로 가는 코드 작성

## 📷 스크린샷 

1. `https://fs12-forest-of-study-teemo-fe.vercel.app/10`과 같이 존재하지 않는 경로로 진입시
[데스크탑, 태블릿 ver]
<img width="1920" height="911" alt="1_에러페이지" src="https://github.com/user-attachments/assets/6bc250a5-944f-4c48-9213-818cb1a00867" />


[모바일 ver]
<img width="500" height="799" alt="2_에러페이지_모바일" src="https://github.com/user-attachments/assets/4f4693d7-52e5-4575-8ca5-6164a71c38e1" />

