### PR TITLE
[Feat] 습관 수정 모달 API 연결

### DIFF
--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -5,6 +5,8 @@ import {
   getTodayHabits,
   postHabit,
   toggleHabit,
+  editHabit,
+  deleteHabit,
 } from '../../services/HabitService';
 import HabitHeader from './HabitComponents/HabitHeader';
 import HabitConfirmModal from './HabitComponents/HabitConfirmModal';
@@ -74,35 +76,42 @@ const TodayHabitPage = () => {
     setEndHabitIds([]);
   };
 
-  // 습관 생성
-  // const createHabit = async () => {
-  //   if (!newHabit.trim() || isSubmitting) {
-  //     return;
-  //   }
-
-  //   try {
-  //     setIsSubmitting(true);
-  //     await postHabit(id, newHabit);
-  //     onCloseModalHandler();
-  //     fetchHabits();
-  //   } catch (error) {
-  //     console.error(error);
-  //   } finally {
-  //     setIsSubmitting(false);
-  //   }
-  // };
-
   // 습관 수정
-  const onConfirmEditHandler = () => {
+  const onConfirmEditHandler = async () => {
     const hasEmptyHabit = editHabits.some((h) => !h.name.trim());
-    if (hasEmptyHabit) {
-      console.log('빈 값 있음');
 
+    if (hasEmptyHabit) {
+      console.log('이름은 필수 입력값입니다.');
       return;
     }
-    console.log('현재 editHabits:', editHabits);
-    console.log('종료 예정 ids:', endHabitIds);
-    onCloseModalHandler();
+
+    const newHabits = editHabits.filter((h) => h.isNew);
+
+    const updatedHabits = editHabits.filter((eH) => {
+      if (eH.isNew) return false;
+
+      const originalHabit = habits.find((h) => h.id === eH.id);
+
+      if (!originalHabit) return false;
+
+      return originalHabit.name !== eH.name.trim();
+    });
+    try {
+      setIsSubmitting(true);
+
+      await Promise.all([
+        ...newHabits.map((h) => postHabit(id, h.name.trim())),
+        ...updatedHabits.map((h) => editHabit(id, h.id, h.name.trim())),
+        ...endHabitIds.map((h) => deleteHabit(id, h)),
+      ]);
+
+      await fetchHabits();
+      onCloseModalHandler();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   // 습관 추가
@@ -125,8 +134,6 @@ const TodayHabitPage = () => {
     }
     setEndHabitIds((prev) => [...prev, habit.id]);
     setEditHabits((prev) => prev.filter((h) => h.id !== habit.id));
-    console.log('현재 editHabits:', editHabits);
-    console.log('종료 예정 ids:', endHabitIds);
   };
 
   return (


### PR DESCRIPTION
## 🔥 Related Issues

- close #119 

## 📒 설명

> 습관 수정 모달에서 생성, 수정, 종료 작업이 실제 API와 연결되도록 구현했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 수정 완료 시 편집 상태를 기준으로 생성 / 수정 / 종료 대상을 분기하도록 구현
- 새로 추가한 습관은 생성 API, 이름이 변경된 기존 습관은 수정 API, 종료 대상 습관은 종료 API와 연결
- 모든 작업 완료 후 오늘의 습관 목록을 재조회하고 모달이 닫히도록 처리

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- 습관 삭제 (종료)

<img width="373" height="390" alt="image" src="https://github.com/user-attachments/assets/fd973ce3-65fd-43c0-b15c-1c4509eb9704" />

<img width="387" height="402" alt="image" src="https://github.com/user-attachments/assets/394104bc-1a64-42d4-87f6-a8d922abe36c" />

- 습관명 수정

<img width="553" height="519" alt="image" src="https://github.com/user-attachments/assets/56286191-891f-47c1-b8cd-042004807200" />

<img width="412" height="340" alt="image" src="https://github.com/user-attachments/assets/ecf882e4-a843-4a87-937f-07c07d30981d" />

## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

- 수정 모달 내부 편집 상태(`editHabits`, `endHabitIds`)를 기준으로 API 호출을 분기했습니다.
- 생성 / 수정 / 종료 요청은 Promise.all로 병렬 처리한 뒤 재조회하도록 구현했습니다.