### PR TITLE
[Refactor] 오늘의 습관 헤더 및 수정 모달 UX 개선

### DIFF
--- a/src/pages/TodayHabitPage/HabitComponents/HabitConfirmModal.jsx
+++ b/src/pages/TodayHabitPage/HabitComponents/HabitConfirmModal.jsx
@@ -9,6 +9,7 @@ const HabitConfirmModal = ({
   setEditHabits,
   onAddHabit,
   onRemoveHabit,
+  errorIndexes,
 }) => {
   return (
     <>
@@ -18,6 +19,7 @@ const HabitConfirmModal = ({
           setEditHabits={setEditHabits}
           onAddHabit={onAddHabit}
           onRemoveHabit={onRemoveHabit}
+          errorIndexes={errorIndexes}
         />
       </HabitModal>
     </>

--- a/src/pages/TodayHabitPage/HabitComponents/HabitEditForm.jsx
+++ b/src/pages/TodayHabitPage/HabitComponents/HabitEditForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from '../TodayHabitPage.module.css';
 
 const HabitEditForm = ({
@@ -6,6 +6,7 @@ const HabitEditForm = ({
   setEditHabits,
   onAddHabit,
   onRemoveHabit,
+  errorIndexes,
 }) => {
   const changeHabitHandler = (id, value) => {
     setEditHabits((prev) =>
@@ -16,12 +17,14 @@ const HabitEditForm = ({
   return (
     <>
       <div className={styles.modifyList}>
-        {editHabits.map((h) => (
+        {editHabits.map((h, index) => (
           <div key={h.id} className={styles.modifyItem}>
             <input
               value={h.name}
               onChange={(e) => changeHabitHandler(h.id, e.target.value)}
-              className={styles.habitInput}
+              className={`${styles.habitInput} ${
+                errorIndexes.includes(index) ? styles.error : ''
+              }`}
             />
             <button
               type="button"

--- a/src/pages/TodayHabitPage/HabitComponents/HabitHeader.jsx
+++ b/src/pages/TodayHabitPage/HabitComponents/HabitHeader.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import styles from '../TodayHabitPage.module.css';
 import LinkButton from '../../../components/LinkButton/LinkButton';
 
-const HabitHeader = ({ studyName, id }) => {
+const HabitHeader = ({ studyUser, studyName, id }) => {
   return (
     <>
       <div className={styles.top}>
-        <h1 className={styles.title}>{studyName}</h1>
+        <h1 className={styles.title}>
+          {studyUser}의 {studyName}
+        </h1>
         <nav className={styles.navContainer}>
           <LinkButton text="오늘의 집중" url={`/${id}/focus`} />
           <LinkButton text="로그" url={`/${id}/logs`} />

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -24,6 +24,7 @@ const TodayHabitPage = () => {
   const [togglingId, setTogglingId] = useState(null);
   const [editHabits, setEditHabits] = useState([]);
   const [endHabitIds, setEndHabitIds] = useState([]);
+  const [errorIndexes, setErrorIndexes] = useState([]);
 
   const { id } = useParams();
 
@@ -82,10 +83,16 @@ const TodayHabitPage = () => {
   const onConfirmEditHandler = async () => {
     if (isSubmitting) return;
 
-    const hasEmptyHabit = editHabits.some((h) => !h.name.trim());
+    const emptyIndexes = editHabits
+      .map((h, index) => (!h.name.trim() ? index : -1))
+      .filter((index) => index !== -1);
 
-    if (hasEmptyHabit) {
-      console.log('이름은 필수 입력값입니다.');
+    if (emptyIndexes.length > 0) {
+      setErrorIndexes(emptyIndexes);
+      setTimeout(() => {
+        setErrorIndexes([]);
+      }, 500);
+
       return;
     }
 
@@ -165,6 +172,7 @@ const TodayHabitPage = () => {
           setEditHabits={setEditHabits}
           onAddHabit={onAddHabitHandler}
           onRemoveHabit={onRemoveHabitHandler}
+          errorIndexes={errorIndexes}
         />
       )}
     </>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -15,6 +15,7 @@ import HabitListHeader from './HabitComponents/HabitListHeader';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 
 const TodayHabitPage = () => {
+  const [studyUser, setStudyUser] = useState('');
   const [studyName, setStudyName] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newHabit, setNewHabit] = useState('');
@@ -31,6 +32,7 @@ const TodayHabitPage = () => {
     try {
       const data = await getTodayHabits(id);
       setStudyName(data.studyTitle);
+      setStudyUser(data.studyNickname);
       setHabits(data.habits);
     } catch (error) {
       console.error(error);
@@ -141,7 +143,7 @@ const TodayHabitPage = () => {
       <div className="wrapper">
         <div className={styles.bodyWrapper}>
           <section className={styles.header}>
-            <HabitHeader studyName={studyName} id={id} />
+            <HabitHeader studyUser={studyUser} studyName={studyName} id={id} />
             <CurrentTime />
           </section>
           <section className={styles.mainSection}>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -80,6 +80,8 @@ const TodayHabitPage = () => {
 
   // 습관 수정
   const onConfirmEditHandler = async () => {
+    if (isSubmitting) return;
+
     const hasEmptyHabit = editHabits.some((h) => !h.name.trim());
 
     if (hasEmptyHabit) {
@@ -98,6 +100,7 @@ const TodayHabitPage = () => {
 
       return originalHabit.name !== eH.name.trim();
     });
+
     try {
       setIsSubmitting(true);
 

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -63,8 +63,6 @@
   font-weight: 800;
 }
 
-/* 습관 수정 모달 */
-
 .listConfirmBtn {
   position: absolute;
   top: 0;
@@ -78,6 +76,8 @@
   background: none;
   border: none;
 }
+
+/* 습관 수정 모달 */
 .modifyList {
   display: flex;
   flex-direction: column;
@@ -96,7 +96,7 @@
   height: 54px;
 
   border-radius: 20px;
-  /* border: none; */
+
   border: 1px solid #ccc;
   transition: all 0.2s ease;
 
@@ -221,5 +221,14 @@
     min-height: 474px;
 
     font-size: 16px;
+  }
+  .modifyList {
+    gap: 8px;
+  }
+  .habitInput {
+    width: 256px;
+  }
+  .plusBtn {
+    margin-top: 24px;
   }
 }

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -96,7 +96,10 @@
   height: 54px;
 
   border-radius: 20px;
-  border: none;
+  /* border: none; */
+  border: 1px solid #ccc;
+  transition: all 0.2s ease;
+
   background: var(--gray_EEEEEE);
 
   color: var(--gray_818181);
@@ -104,6 +107,10 @@
   font-size: 16px;
   font-weight: 700;
   text-decoration: underline;
+}
+
+.error {
+  border: 1px solid #ff4d4f;
 }
 
 .removeBtn {


### PR DESCRIPTION
## 🔥 Related Issues

- close #127 

## 📒 설명

> 오늘의 습관 페이지에서 헤더 정보 표시와 수정 모달 UX를 개선했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 오늘의 습관 헤더에 스터디 생성자 정보를 표시하도록 수정했습니다.
- 수정 모달 확인 버튼의 중복 요청 방지 로직을 추가했습니다.
- 수정 모달에서 빈 입력값 검증 및 에러 UI(빈 입력 강조)를 적용했습니다.
- 수정 모달 반응형 스타일을 추가했습니다.

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/2f1356ca-0e21-425d-96e5-69b291afe1ba" />

## 📦 참고사항 (선택사항)

> 수정 모달 입력값 검증 시 빈 입력 필드를 한 번에 확인할 수 있도록 에러 상태를 배열로 관리했습니다.
