### PR TITLE
[Chore] 오늘의 집중 페이지 타이틀 수정 및 CSS 개선

### DIFF
--- a/src/hooks/useFetchTimer.js
+++ b/src/hooks/useFetchTimer.js
@@ -25,7 +25,7 @@ const useFetchTimer = (studyId) => {
         const data = await getTimer(studyId);
         const timerData = data.timer;
         const total = await getTotalPoint(studyId);
-        setTitle(data.title);
+        setTitle(`${data.nickname}의 ${data.title}`);
         if (!timerData) {
           initTimer();
           await createTimer(studyId);

--- a/src/pages/TodayFocusPage/TodayFocus.jsx
+++ b/src/pages/TodayFocusPage/TodayFocus.jsx
@@ -62,7 +62,7 @@ const TodayFocus = () => {
 
   return (
     <>
-      <div className="wrapper">
+      <div className={`wrapper ${styles.wrapper}`}>
         <div className={styles.focusWrapper}>
           <div>
             <FocusHeader studyId={id} title={title} />

--- a/src/pages/TodayFocusPage/TodayFocus.module.css
+++ b/src/pages/TodayFocusPage/TodayFocus.module.css
@@ -1,3 +1,7 @@
+.wrapper {
+  margin-bottom: 80px;
+}
+
 .focusWrapper {
   display: flex;
   flex-direction: column;

--- a/src/pages/TodayFocusPage/components/FocusHeader/FocusHeader.module.css
+++ b/src/pages/TodayFocusPage/components/FocusHeader/FocusHeader.module.css
@@ -1,11 +1,13 @@
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  gap: 10px;
 }
 
 .navContainer {
   display: flex;
+  min-width: 357px;
+  max-height: 50px;
   gap: 16px;
 }
 
@@ -22,6 +24,8 @@
   }
 
   .navContainer {
+    min-width: 0;
+    max-height: 42px;
     gap: 8px;
   }
 }

--- a/src/pages/TodayFocusPage/components/Timer/Timer.module.css
+++ b/src/pages/TodayFocusPage/components/Timer/Timer.module.css
@@ -25,6 +25,7 @@
 .startBtn {
   display: flex;
   align-items: center;
+  height: 64px;
   gap: 16px;
   border-radius: 50px;
   background: var(--brand_99C08E);
@@ -65,6 +66,7 @@
   }
 
   .startBtn {
+    height: 48.39px;
     gap: 8px;
     padding: 11px 28px 11px 20px;
     font-size: 18px;


### PR DESCRIPTION
## 🔥 Related Issues

- close #129 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

오늘의 집중 페이지의 타이틀에 닉네임과 제목이 함께 보이게 하고 css를 조금 수정

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- fetchTimer에서 nickname도 받아 타이틀을 `nickname의 title`로 수정
- 타이틀이 길어짐에 따라 css 수정
- 레이아웃 수정

## 📷 스크린샷 
<img width="1920" height="1065" alt="26 04 21_타이틀 수정" src="https://github.com/user-attachments/assets/00d6f5b4-3f7d-4193-86b6-87f8db3daa50" />

