### PR TITLE
[Feat] 오늘의 집중 페이지 스켈레톤 UI 구현

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -46,7 +46,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .gnbContainer {
     margin: 0 16px;
     padding: 32px 0;

--- a/src/components/LinkButton/LinkButton.module.css
+++ b/src/components/LinkButton/LinkButton.module.css
@@ -11,7 +11,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .linkBtn {
     padding: 8px 6px 8px 10px;
   }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -8,6 +8,33 @@
   animation: shimmer 1.4s infinite;
 }
 
+.totalPointSkeletonContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.totalPointTitleSkeleton {
+  width: 165px;
+  height: 27px;
+
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+.totalPointSkeleton {
+  width: 100px;
+  height: 36px;
+
+  border-radius: 50px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
 @keyframes shimmer {
   0% {
     background-position: 100% 0;
@@ -34,9 +61,13 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .studyNameSkeleton {
     width: 180px;
     height: 36px;
+  }
+
+  .totalPointSkeletonContainer {
+    margin-top: 72px;
   }
 }

--- a/src/components/Loading/TotalPointSkeleton.jsx
+++ b/src/components/Loading/TotalPointSkeleton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './Loading.module.css';
+
+const TotalPointSkeleton = () => {
+  return (
+    <div className={styles.totalPointSkeletonContainer}>
+      <div className={styles.totalPointTitleSkeleton}></div>
+      <div className={styles.totalPointSkeleton}></div>
+    </div>
+  );
+};
+
+export default TotalPointSkeleton;

--- a/src/hooks/useFetchTimer.js
+++ b/src/hooks/useFetchTimer.js
@@ -5,7 +5,7 @@ import { getTotalPoint } from '../services/PointService';
 /*------------------------------------------
      타이머 데이터를 받아오는 커스텀 Hook
 -------------------------------------------*/
-const useFetchTimer = (studyId) => {
+const useFetchTimer = (studyId, setIsLoading) => {
   const [targetDuration, setTargetDuration] = useState(0);
   const [timerCount, setTimerCount] = useState(targetDuration);
   const [timerStatus, setTimerStatus] = useState('CANCELED');
@@ -22,6 +22,7 @@ const useFetchTimer = (studyId) => {
 
   useEffect(() => {
     try {
+      setIsLoading(true);
       const fetchTimer = async () => {
         const data = await getTimer(studyId);
         if (!data) {
@@ -59,13 +60,15 @@ const useFetchTimer = (studyId) => {
         } else {
           setTimerCount(timer.targetDuration - timer.elapsedTime + 700);
         }
+
+        setIsLoading(false);
       };
 
       fetchTimer();
     } catch (error) {
       console.error(error);
     }
-  }, [studyId]);
+  }, [studyId, setIsLoading]);
 
   return {
     targetDuration,

--- a/src/pages/NotFoundPage/NotFound.module.css
+++ b/src/pages/NotFoundPage/NotFound.module.css
@@ -41,7 +41,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .errCode {
     font-size: 36px;
   }

--- a/src/pages/TodayFocusPage/TodayFocus.jsx
+++ b/src/pages/TodayFocusPage/TodayFocus.jsx
@@ -9,9 +9,15 @@ import useFetchTimer from '../../hooks/useFetchTimer';
 import useTargetDuration from '../../hooks/useTargetDuration';
 import useTimer from '../../hooks/useTimer';
 import NotFound from '../NotFoundPage/NotFound';
+import { useState } from 'react';
+import ContentSpinner from '../../components/Loading/ContentSpinner';
+import StudyNameSkeleton from '../../components/Loading/StudyNameSkeleton';
+import TotalPointSkeleton from '../../components/Loading/TotalPointSkeleton';
 
 const TodayFocus = () => {
   const { id } = useParams();
+  const [isLoading, setIsLoading] = useState(true);
+
   const {
     targetDuration,
     setTargetDuration,
@@ -23,7 +29,7 @@ const TodayFocus = () => {
     setTotalPoint,
     title,
     isNotFoundError,
-  } = useFetchTimer(id);
+  } = useFetchTimer(id, setIsLoading);
 
   const {
     toggleForm,
@@ -74,39 +80,56 @@ const TodayFocus = () => {
           <div className={`wrapper ${styles.wrapper}`}>
             <div className={styles.focusWrapper}>
               <div>
-                <FocusHeader studyId={id} title={title} />
-                <TotalPoints points={totalPoint} />
+                {isLoading ? (
+                  <>
+                    <StudyNameSkeleton />
+                    <TotalPointSkeleton />
+                  </>
+                ) : (
+                  <>
+                    <FocusHeader studyId={id} title={title} />
+                    <TotalPoints points={totalPoint} />
+                  </>
+                )}
               </div>
               <main className={styles.timerWrapper}>
-                <div className={styles.timerHeader}>
-                  <h2>오늘의 집중</h2>
-                  <TargetDuration
-                    targetDuration={targetDuration}
-                    toggleForm={toggleForm}
-                    error={error}
-                    setError={setError}
-                    hours={hours}
-                    setHours={setHours}
-                    minutes={minutes}
-                    setMinutes={setMinutes}
-                    seconds={seconds}
-                    setSeconds={setSeconds}
-                    onToggleForm={toggleFormHandler}
-                    onChangeHours={hoursInputHandler}
-                    onChangeMinutes={minutesInputHandler}
-                    onChangeSeconds={secondsInputHandler}
-                    onSubmitTarget={submitHandler}
-                  />
-                </div>
-                <Timer
-                  timerCount={timerCount}
-                  toggleForm={toggleForm}
-                  timerStatus={timerStatus}
-                  onStart={timerStartHandler}
-                  onPause={timerPauseHandler}
-                  onReset={timerResetHandler}
-                  onComplete={timerCompleteHandler}
-                />
+                {isLoading ? (
+                  <div className={styles.spinnerContainer}>
+                    <ContentSpinner />
+                  </div>
+                ) : (
+                  <>
+                    <div className={styles.timerHeader}>
+                      <h2>오늘의 집중</h2>
+                      <TargetDuration
+                        targetDuration={targetDuration}
+                        toggleForm={toggleForm}
+                        error={error}
+                        setError={setError}
+                        hours={hours}
+                        setHours={setHours}
+                        minutes={minutes}
+                        setMinutes={setMinutes}
+                        seconds={seconds}
+                        setSeconds={setSeconds}
+                        onToggleForm={toggleFormHandler}
+                        onChangeHours={hoursInputHandler}
+                        onChangeMinutes={minutesInputHandler}
+                        onChangeSeconds={secondsInputHandler}
+                        onSubmitTarget={submitHandler}
+                      />
+                    </div>
+                    <Timer
+                      timerCount={timerCount}
+                      toggleForm={toggleForm}
+                      timerStatus={timerStatus}
+                      onStart={timerStartHandler}
+                      onPause={timerPauseHandler}
+                      onReset={timerResetHandler}
+                      onComplete={timerCompleteHandler}
+                    />
+                  </>
+                )}
               </main>
             </div>
           </div>

--- a/src/pages/TodayFocusPage/TodayFocus.module.css
+++ b/src/pages/TodayFocusPage/TodayFocus.module.css
@@ -27,6 +27,13 @@
   gap: 24px;
 }
 
+.spinnerContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 482px;
+}
+
 /* 태블릿 */
 @media (max-width: 1024px) {
   .focusWrapper {
@@ -35,7 +42,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .focusWrapper {
     gap: 24px;
   }
@@ -47,5 +54,9 @@
 
   .timerHeader {
     gap: 16px;
+  }
+
+  .spinnerContainer {
+    min-height: 334.375px;
   }
 }

--- a/src/pages/TodayFocusPage/components/FocusHeader/FocusHeader.module.css
+++ b/src/pages/TodayFocusPage/components/FocusHeader/FocusHeader.module.css
@@ -12,7 +12,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .header {
     flex-direction: column;
     align-items: start;

--- a/src/pages/TodayFocusPage/components/Timer/Timer.module.css
+++ b/src/pages/TodayFocusPage/components/Timer/Timer.module.css
@@ -52,7 +52,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .timerContainer {
     gap: 64px;
   }


### PR DESCRIPTION
## 🔥 Related Issues

- close #157 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

오늘의 집중 페이지에서 서버로부터 데이터를 받아오는 중에 유저에게 보여줄 스켈레톤 UI 구현

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 총합 포인트 스켈레톤 UI 공통 컴포넌트로 구현
- 오늘의 집중 페이지에서 state를 이용해 로딩중일 때, 스켈레톤 UI 렌더링
- 모바일 반응형 width 수정

## 📷 스크린샷 
### 1. 오늘의 집중 페이지 스켈레톤 UI (데스크탑, 태블릿 ver)
<img width="1410" height="902" alt="1_오늘의_집중_페이지_스켈레톤_UI_데스크탑" src="https://github.com/user-attachments/assets/569c15ca-def7-4f71-a861-603e82b0d841" />


### 2. 오늘의 집중 페이지 스켈레톤 UI (모바일 ver)
<img width="577" height="766" alt="2_오늘의_집중_페이지_스켈레톤_UI_모바일" src="https://github.com/user-attachments/assets/026fbe30-e94a-4ad6-b547-88ac75c001ee" />


## 📦 참고사항

총합 포인트 스켈레톤 UI는 공통으로 쓸 수도 있을 것 같아 공통 컴포넌트로 구현해두었습니다!
