### PR TITLE
[Feat] 오늘의 습관 페이지 로직 분리 및 스켈레톤 UI 개선

### DIFF
--- a/src/components/Loading/CurrentTimeSkeleton.jsx
+++ b/src/components/Loading/CurrentTimeSkeleton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './Loading.module.css';
+
+const CurrentTimeSkeleton = () => {
+  return (
+    <div className={styles.currentTimeSkeletonContainer}>
+      <div className={styles.currentTimeTitleSkeleton}></div>
+      <div className={styles.currentTimeSkeleton}></div>
+    </div>
+  );
+};
+
+export default CurrentTimeSkeleton;

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -8,6 +8,32 @@
   animation: shimmer 1.4s infinite;
 }
 
+.currentTimeSkeletonContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.currentTimeTitleSkeleton {
+  width: 78px;
+  height: 27px;
+
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+.currentTimeSkeleton {
+  width: 190px;
+  height: 36px;
+
+  border-radius: 50px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
 .totalPointSkeletonContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/Modal/HabitModal/HabitModal.module.css
+++ b/src/components/Modal/HabitModal/HabitModal.module.css
@@ -19,7 +19,7 @@
 
   margin-top: 24px;
 }
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .header {
     margin-bottom: 16px;
   }

--- a/src/components/Modal/ModalLayout.module.css
+++ b/src/components/Modal/ModalLayout.module.css
@@ -18,7 +18,7 @@
   flex-direction: column;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .container {
     padding: 16px 16px 24px 16px;
     border-radius: 20px;

--- a/src/components/Modal/PasswordModal/PasswordModal.module.css
+++ b/src/components/Modal/PasswordModal/PasswordModal.module.css
@@ -48,7 +48,7 @@
   background: none;
   border: none;
 }
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .header {
     margin-bottom: 16px;
   }

--- a/src/hooks/useHabitModal.js
+++ b/src/hooks/useHabitModal.js
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { postHabit, editHabit, deleteHabit } from '../services/HabitService';
+
+const useHabitModal = ({ id, habits, fetchHabits, inputClassName }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editHabits, setEditHabits] = useState([]);
+  const [endHabitIds, setEndHabitIds] = useState([]);
+  const [errorInfos, setErrorInfos] = useState([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 습관 수정 모달 열기
+  const onOpenModalHandler = () => {
+    setEditHabits(habits);
+    setEndHabitIds([]);
+    setErrorInfos([]);
+    setIsModalOpen(true);
+  };
+
+  // 습관 수정 모달 닫기
+  const onCloseModalHandler = () => {
+    setIsModalOpen(false);
+    setEditHabits([]);
+    setEndHabitIds([]);
+    setErrorInfos([]);
+  };
+
+  // 습관 수정
+  const onConfirmEditHandler = async () => {
+    if (isSubmitting) return;
+
+    // 습관명 무결성 검사
+    const errors = editHabits
+      .map((h, index) => {
+        const name = h.name.trim();
+
+        if (!name) {
+          return { index, message: '이름은 필수 입력입니다.' };
+        }
+
+        if (name.length < 2) {
+          return { index, message: '2자 이상 입력해주세요' };
+        }
+
+        if (name.length > 20) {
+          return { index, message: '20자 이하로 입력해주세요' };
+        }
+
+        return null;
+      })
+      .filter(Boolean);
+
+    if (errors.length > 0) {
+      setErrorInfos(errors);
+      return;
+    }
+
+    const newHabits = editHabits.filter((h) => h.isNew);
+
+    const updatedHabits = editHabits.filter((editedHabit) => {
+      if (editedHabit.isNew) return false;
+
+      const originalHabit = habits.find((h) => h.id === editedHabit.id);
+      if (!originalHabit) return false;
+
+      return originalHabit.name !== editedHabit.name.trim();
+    });
+
+    try {
+      setIsSubmitting(true);
+
+      for (const habit of newHabits) {
+        await postHabit(id, habit.name.trim());
+      }
+
+      await Promise.all([
+        ...updatedHabits.map((habit) =>
+          editHabit(id, habit.id, habit.name.trim()),
+        ),
+        ...endHabitIds.map((habitId) => deleteHabit(id, habitId)),
+      ]);
+
+      await fetchHabits();
+      onCloseModalHandler();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 습관 추가
+  const onAddHabitHandler = () => {
+    setEditHabits((prev) => [
+      ...prev,
+      {
+        id: `temp-${Date.now()}`,
+        name: '',
+        isNew: true,
+      },
+    ]);
+
+    setTimeout(() => {
+      const inputs = document.querySelectorAll(`.${inputClassName}`);
+      const lastInput = inputs[inputs.length - 1];
+      lastInput?.focus();
+    }, 0);
+  };
+
+  // 습관 종료
+  const onRemoveHabitHandler = (habit) => {
+    if (habit.isNew) {
+      setEditHabits((prev) => prev.filter((h) => h.id !== habit.id));
+      return;
+    }
+
+    setEndHabitIds((prev) => [...prev, habit.id]);
+    setEditHabits((prev) => prev.filter((h) => h.id !== habit.id));
+  };
+
+  return {
+    isModalOpen,
+    editHabits,
+    setEditHabits,
+    errorInfos,
+    setErrorInfos,
+    isSubmitting,
+    onOpenModalHandler,
+    onCloseModalHandler,
+    onConfirmEditHandler,
+    onAddHabitHandler,
+    onRemoveHabitHandler,
+  };
+};
+
+export default useHabitModal;

--- a/src/hooks/useTodayHabits.js
+++ b/src/hooks/useTodayHabits.js
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { getTodayHabits, toggleHabit } from '../services/HabitService';
+
+const useTodayHabits = (id) => {
+  const [studyUser, setStudyUser] = useState('');
+  const [studyName, setStudyName] = useState('');
+  const [habits, setHabits] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [togglingId, setTogglingId] = useState(null);
+
+  // 오늘의 습관 조회
+  const fetchHabits = async () => {
+    setIsLoading(true);
+
+    try {
+      const data = await getTodayHabits(id);
+      setStudyName(data.studyTitle);
+      setStudyUser(data.studyNickname);
+      setHabits(data.habits);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!id) return;
+    fetchHabits();
+  }, [id]);
+
+  // 습관 완료 토글
+  const onToggleHabitHandler = async (habitId) => {
+    if (togglingId === habitId) return;
+
+    try {
+      setTogglingId(habitId);
+
+      await toggleHabit(id, habitId);
+
+      setHabits((prev) =>
+        prev.map((h) =>
+          h.id === habitId ? { ...h, isCompleted: !h.isCompleted } : h,
+        ),
+      );
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  return {
+    studyUser,
+    studyName,
+    habits,
+    isLoading,
+    togglingId,
+    fetchHabits,
+    onToggleHabitHandler,
+  };
+};
+
+export default useTodayHabits;

--- a/src/pages/TodayHabitPage/HabitComponents/HabitHeader.jsx
+++ b/src/pages/TodayHabitPage/HabitComponents/HabitHeader.jsx
@@ -10,16 +10,17 @@ const HabitHeader = ({ studyUser, studyName, id, isLoading }) => {
         {isLoading ? (
           <StudyNameSkeleton />
         ) : (
-          <h1 className={styles.title}>
-            {studyUser}의 {studyName}
-          </h1>
+          <>
+            <h1 className={styles.title}>
+              {studyUser}의 {studyName}
+            </h1>
+            <nav className={styles.navContainer}>
+              <LinkButton text="오늘의 집중" url={`/${id}/focus`} />
+              <LinkButton text="로그" url={`/${id}/logs`} />
+              <LinkButton text="홈" url={`/${id}/detail`} />
+            </nav>
+          </>
         )}
-
-        <nav className={styles.navContainer}>
-          <LinkButton text="오늘의 집중" url={`/${id}/focus`} />
-          <LinkButton text="로그" url={`/${id}/logs`} />
-          <LinkButton text="홈" url={`/${id}/detail`} />
-        </nav>
       </div>
     </>
   );

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -15,31 +15,19 @@ import HabitListHeader from './HabitComponents/HabitListHeader';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 import ContentSpinner from '../../components/Loading/ContentSpinner';
 import useHabitModal from '../../hooks/useHabitModal';
+import useTodayHabits from '../../hooks/useTodayHabits';
 
 const TodayHabitPage = () => {
-  const [studyUser, setStudyUser] = useState('');
-  const [studyName, setStudyName] = useState('');
-  const [habits, setHabits] = useState([]);
-  const [togglingId, setTogglingId] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
-
   const { id } = useParams();
 
-  // 오늘의 습관 조회
-  const fetchHabits = async () => {
-    setIsLoading(true);
-
-    try {
-      const data = await getTodayHabits(id);
-      setStudyName(data.studyTitle);
-      setStudyUser(data.studyNickname);
-      setHabits(data.habits);
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const {
+    studyUser,
+    studyName,
+    habits,
+    isLoading,
+    fetchHabits,
+    onToggleHabitHandler,
+  } = useTodayHabits(id);
 
   const {
     isModalOpen,
@@ -58,31 +46,6 @@ const TodayHabitPage = () => {
     fetchHabits,
     inputClassName: styles.habitInput,
   });
-
-  useEffect(() => {
-    fetchHabits();
-  }, [id]);
-
-  // 습관 완료 토글
-  const onToggleHabitHandler = async (habitId) => {
-    if (togglingId === habitId) return;
-
-    try {
-      setTogglingId(habitId);
-
-      await toggleHabit(id, habitId);
-
-      setHabits((prevHabits) =>
-        prevHabits.map((h) =>
-          h.id === habitId ? { ...h, isCompleted: !h.isCompleted } : h,
-        ),
-      );
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setTogglingId(null);
-    }
-  };
 
   return (
     <>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -14,6 +14,7 @@ import HabitList from './HabitComponents/HabitList';
 import HabitListHeader from './HabitComponents/HabitListHeader';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 import ContentSpinner from '../../components/Loading/ContentSpinner';
+import CurrentTimeSkeleton from '../../components/Loading/CurrentTimeSkeleton';
 import useHabitModal from '../../hooks/useHabitModal';
 import useTodayHabits from '../../hooks/useTodayHabits';
 
@@ -58,22 +59,22 @@ const TodayHabitPage = () => {
               id={id}
               isLoading={isLoading}
             />
-            <CurrentTime />
+            {isLoading ? <CurrentTimeSkeleton /> : <CurrentTime />}
           </section>
           <section className={styles.mainSection}>
-            <div className={styles.todayHabit}>
-              <HabitListHeader onOpenModal={onOpenModalHandler} />{' '}
-              {isLoading ? (
-                <div className={styles.loadingBox}>
-                  <ContentSpinner />
-                </div>
-              ) : (
+            {isLoading ? (
+              <div className={styles.loadingBox}>
+                <ContentSpinner />
+              </div>
+            ) : (
+              <div className={styles.todayHabit}>
+                <HabitListHeader onOpenModal={onOpenModalHandler} />
                 <HabitList
                   habits={habits}
                   onToggleHabit={onToggleHabitHandler}
                 />
-              )}
-            </div>
+              </div>
+            )}
           </section>
         </div>
       </div>

--- a/src/pages/TodayHabitPage/TodayHabitPage.jsx
+++ b/src/pages/TodayHabitPage/TodayHabitPage.jsx
@@ -14,18 +14,13 @@ import HabitList from './HabitComponents/HabitList';
 import HabitListHeader from './HabitComponents/HabitListHeader';
 import CurrentTime from '../../components/CurrentTime/CurrentTime';
 import ContentSpinner from '../../components/Loading/ContentSpinner';
+import useHabitModal from '../../hooks/useHabitModal';
 
 const TodayHabitPage = () => {
   const [studyUser, setStudyUser] = useState('');
   const [studyName, setStudyName] = useState('');
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [newHabit, setNewHabit] = useState('');
   const [habits, setHabits] = useState([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [togglingId, setTogglingId] = useState(null);
-  const [editHabits, setEditHabits] = useState([]);
-  const [endHabitIds, setEndHabitIds] = useState([]);
-  const [errorInfos, setErrorInfos] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const { id } = useParams();
@@ -45,6 +40,24 @@ const TodayHabitPage = () => {
       setIsLoading(false);
     }
   };
+
+  const {
+    isModalOpen,
+    editHabits,
+    setEditHabits,
+    errorInfos,
+    setErrorInfos,
+    onOpenModalHandler,
+    onCloseModalHandler,
+    onConfirmEditHandler,
+    onAddHabitHandler,
+    onRemoveHabitHandler,
+  } = useHabitModal({
+    id,
+    habits,
+    fetchHabits,
+    inputClassName: styles.habitInput,
+  });
 
   useEffect(() => {
     fetchHabits();
@@ -69,114 +82,6 @@ const TodayHabitPage = () => {
     } finally {
       setTogglingId(null);
     }
-  };
-
-  // 습관 수정 모달 열기
-  const onOpenModalHandler = () => {
-    setEditHabits(habits);
-    setEndHabitIds([]);
-    setIsModalOpen(true);
-  };
-
-  // 습관 수정 모달 닫기
-  const onCloseModalHandler = () => {
-    setIsModalOpen(false);
-    setEditHabits([]);
-    setEndHabitIds([]);
-    setErrorInfos([]);
-  };
-
-  // 습관 수정
-  const onConfirmEditHandler = async () => {
-    if (isSubmitting) return;
-
-    // 습관명 오류 메세지
-    const errors = editHabits
-      .map((h, index) => {
-        const name = h.name.trim();
-
-        if (!name) {
-          return { index, message: '이름은 필수 입력입니다.' };
-        }
-
-        if (name.length < 2) {
-          return { index, message: '2자 이상 입력해주세요' };
-        }
-
-        if (name.length > 20) {
-          return { index, message: '20자 이하로 입력해주세요' };
-        }
-
-        return null;
-      })
-
-      .filter(Boolean);
-
-    if (errors.length > 0) {
-      setErrorInfos(errors);
-
-      return;
-    }
-
-    const newHabits = editHabits.filter((h) => h.isNew);
-
-    const updatedHabits = editHabits.filter((eH) => {
-      if (eH.isNew) return false;
-
-      const originalHabit = habits.find((h) => h.id === eH.id);
-
-      if (!originalHabit) return false;
-
-      return originalHabit.name !== eH.name.trim();
-    });
-
-    try {
-      setIsSubmitting(true);
-
-      for (const h of newHabits) {
-        await postHabit(id, h.name.trim());
-      }
-
-      await Promise.all([
-        ...updatedHabits.map((h) => editHabit(id, h.id, h.name.trim())),
-        ...endHabitIds.map((h) => deleteHabit(id, h)),
-      ]);
-
-      await fetchHabits();
-      onCloseModalHandler();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  // 습관 추가
-  const onAddHabitHandler = () => {
-    setEditHabits((prev) => [
-      ...prev,
-      {
-        id: `temp-${Date.now()}`,
-        name: '',
-        isNew: true,
-      },
-    ]);
-
-    setTimeout(() => {
-      const inputs = document.querySelectorAll(`.${styles.habitInput}`);
-      const lastInput = inputs[inputs.length - 1];
-      lastInput?.focus();
-    }, 0);
-  };
-
-  // 습관 종료
-  const onRemoveHabitHandler = (habit) => {
-    if (habit.isNew) {
-      setEditHabits((prev) => prev.filter((h) => h.id !== habit.id));
-      return;
-    }
-    setEndHabitIds((prev) => [...prev, habit.id]);
-    setEditHabits((prev) => prev.filter((h) => h.id !== habit.id));
   };
 
   return (

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -203,9 +203,10 @@
 .loadingBox {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
   padding: 40px 0;
-  min-height: 498px;
+  min-height: 558px;
 }
 
 /* 태블릿 */

--- a/src/pages/TodayHabitPage/TodayHabitPage.module.css
+++ b/src/pages/TodayHabitPage/TodayHabitPage.module.css
@@ -216,7 +216,7 @@
 }
 
 /* 모바일 */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .bodyWrapper {
     gap: 24px;
   }


### PR DESCRIPTION
## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 12주차
- **PR 요약**: TodayHabitPage에 몰려 있던 로직을 커스텀 훅으로 분리했습니다.

---

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

- useTodayHabits, useHabitModal 커스텀 훅으로 TodayHabitPage 로직 분리
- TodayHabitPage의 조회/토글/모달 관련 책임 정리

---

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1

- **파일/위치**: `src/pages/TodayHabitPage/TodayHabitPage.jsx`, `src/pages/TodayHabitPage/hooks/useTodayHabits.js`, `src/pages/TodayHabitPage/hooks/useHabitModal.js`
- **요청 내용**:
  > 기존에는 `TodayHabitPage.jsx`에 조회, 토글, 모달 관련 상태와 핸들러가 함께 있어서 파일이 길고 복잡해지는 느낌이 있었습니다.  
  > 그래서 일부 로직을 커스텀 훅으로 분리해 페이지 컴포넌트는 조금 더 렌더링 중심으로 보이도록 정리했습니다.  
  > 다만 불필요하게 훅을 많이 분리한 것 같진 않은지, 훅 분리가 과한 편인지 궁금합니다.
- **고민한 점**:
  > 훅으로 분리하니 `TodayHabitPage.jsx`는 깔끔해졌지만, 실제 동작 흐름을 보려면 훅 파일까지 함께 확인해야 해서 오히려 파악이 어려워질 수도 있다고 느꼈습니다.  
  > 현재처럼 분리하는 것이 적절한지, 아니면 페이지 내부에 두는 편이 더 나은 로직이 있는지 피드백 받고 싶습니다.

---

## ⚠️ 특이사항 / 참고 사항

- 커스텀 훅 분리가 과한지, 적절한지에 대한 피드백을 가장 중점적으로 받고 싶습니다.

---
---

## 🔥 Related Issues

- close #160 

## 📒 설명

> TodayHabitPage에 몰려 있던 로직을 커스텀 훅으로 분리하고, 로딩 UI를 스켈레톤 기반으로 개선했습니다.
추가로 반응형 기준을 767px로 조정했습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- useTodayHabits, useHabitModal 커스텀 훅으로 TodayHabitPage 로직 분리
- TodayHabitPage의 조회/토글/모달 관련 책임 정리
- 로딩 UI에 CurrentTimeSkeleton 적용
- 스켈레톤 스타일 확장 및 로딩 구조 개선
- 반응형 기준을 767px로 수정

## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

혜성님 UI를 참고하여 CurrentTimeSkeleton을 공통 컴포넌트로 제작했습니다 ...