### PR TITLE
[Feat] 로그페이지 페이지네이션 백엔드 연동 및 UI 개선

### DIFF
--- a/src/pages/LogPage/LogPage.jsx
+++ b/src/pages/LogPage/LogPage.jsx
@@ -7,6 +7,7 @@ import LogList from './components/LogList/LogList';
 import { getLogs } from '../../services/LogService';
 import { formatDate } from '../../utils/formattedDate';
 import { getStudyDetail } from '../../services/StudyService';
+import Pagenation from '../../components/Pagination/Pagination';
 
 
 const LogPage = () => {
@@ -14,23 +15,47 @@ const LogPage = () => {
   const [study, setStudy] = useState([]);
   const [logType, setLogType] = useState("focus");
   const [date, setDate] = useState(new Date());
+
   const [pointLogs, setPointLogs] = useState([]);
   const [focusLogs, setFocusLogs] = useState([]);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pagination, setPagination] = useState({
+    totalPages: 1,
+  });
+
+  const pageChangeHandler = (page) => {
+    if (page < 1 || page > pagination.totalPages || page === currentPage) {
+      return;
+    }
+    setCurrentPage(page);
+  }
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [date, logType]);
+
+  useEffect(() => {
+      const fetchStudyData = async () => {
+        const studyData = await getStudyDetail(id);
+        setStudy(studyData);
+      };
+      fetchStudyData();
+    }, [id]);
 
   useEffect(() => {
     const fetchData = async () => {
       const formattedDate = formatDate(date);
-        const data = await getLogs(id, formattedDate);
+      const result = await getLogs(id, formattedDate, currentPage);
 
-        setPointLogs(data);
-        setFocusLogs(data);
-
-        const studyData = await getStudyDetail(id);
-        setStudy(studyData);
-      } 
-
+      if (result.success) {
+        setPointLogs(result.data.logs);
+        setFocusLogs(result.data.logs);
+        setPagination(result.data.pagination);
+      }
+    };
     fetchData();
-  }, [date, id]);
+  }, [date, id, currentPage]);
 
 
   return (
@@ -58,6 +83,9 @@ const LogPage = () => {
           logType={logType}
           pointLogs={pointLogs}
           focusLogs={focusLogs}
+          currentPage={currentPage}
+          totalPages={pagination.totalPages}
+          onPageChange={pageChangeHandler}
         />
       </div>
     </div>

--- a/src/pages/LogPage/components/LogList/LogList.jsx
+++ b/src/pages/LogPage/components/LogList/LogList.jsx
@@ -1,51 +1,21 @@
-import { useState } from 'react';
 import styles from './LogList.module.css';
 import { formattedTime } from '../../../../utils/formattedTime';
 import { formatKST } from "../../../../utils/formattedDate";
 import { calculateDailyTotals } from '../../../../utils/logCalculator';
+import Pagination from '../../../../components/Pagination/Pagination';
 
-const LogList = ({ logType, pointLogs, focusLogs }) => {
-  const [currentPage, setCurrentPage] = useState(1);
-  const pageItems = 5;
-  const pageLimit = 5;
-
-  const logList = logType === "point" ? pointLogs : focusLogs;
-  const hasData = logList && logList.length > 0;
-  const {point, focus } = calculateDailyTotals(pointLogs, focusLogs);
-
-  const totalPages = Math.ceil((logList?.length || 0) / pageItems);
-
-  const startPageNumber = (currentPage - 1) * pageItems;
-  const currentItems = logList?.slice(startPageNumber, startPageNumber + pageItems);
-
-  const startPageBlock = Math.floor((currentPage -1) / pageLimit) * pageLimit + 1;
-  const endPageBlock = Math.min(startPageBlock + pageLimit -1, totalPages);
-
-  // 페이지 이동 핸들러
-  const goToFirstHandler = () => {
-    setCurrentPage(1);
-    return;
-  }
-
-  const goToLastHandler = () => {
-    setCurrentPage(totalPages);
-  };
-
-  const gotoPrevHandler = () => {
-    setCurrentPage((prev) => {
-      const prevPage = Math.max(1, prev -1);
-      return prevPage;
-    });
-    return;
-  }
-
-  const goToNextHandler = () => {
-    setCurrentPage((prev) => {
-    const nextPage = Math.min(totalPages, prev + 1);
-    return nextPage;
-    });
-    return;
-  }
+const LogList = ({ 
+  logType,
+  pointLogs,
+  focusLogs,
+  currentPage,
+  totalPages,
+  onPageChange
+}) => {
+  const currentItems = logType === "point" ? pointLogs : focusLogs;
+  const hasData = currentItems && currentItems.length > 0;
+  
+  const { point, focus } = calculateDailyTotals(pointLogs, focusLogs);
 
   return (
     <>
@@ -70,65 +40,31 @@ const LogList = ({ logType, pointLogs, focusLogs }) => {
 
       {/* 리스트 */}
         <div className={styles.list}>
-          {hasData ? (
-            <>
-              {currentItems.map((item) => (
-                <div 
-                  key={item.id || item.createdAt} 
-                  className={styles.row}
-                >
-                <span 
-                className={styles.rowDate}>
-                  {formatKST(item.createdAt)} 
-                </span>
+      {hasData ? (
+        <>
+          <div className={styles.rowsContainer}>
+            {currentItems.map((item) => (
+              <div key={item.id} className={styles.row}>
+                <span className={styles.rowDate}>{formatKST(item.createdAt)}</span>
                 <span className={styles.rowValue}>
-                  {logType === "point" ? `${item.points} P` 
-                  : formattedTime(item.focusDuration)}
+                  {logType === "point" ? `${item.points} P` : formattedTime(item.focusDuration)}
                 </span>
-                </div>
-              ))}
-            </>
-          ) : (
-            <p className={styles.noData}>해당 날짜의 기록이 없어요.</p>
-          )}
+              </div>
+            ))}
+          </div>
 
-          {hasData && (
-            <div className={styles.pagination}>
-                <button
-                  onClick={goToFirstHandler}
-                  disabled={currentPage === 1}
-                  >{"<<"} </button>
-                <button
-                  onClick={gotoPrevHandler}
-                  disabled={currentPage === 1}
-                  >{"<"}</button>
-
-              {[...Array(endPageBlock - startPageBlock + 1)].map((_, index) => {
-                const pageNumber = startPageBlock + index;
-                return (
-                  <button
-                  key={pageNumber}
-                  onClick={() => {
-                    setCurrentPage(pageNumber)
-                  }}
-                  className={currentPage === pageNumber ? styles.activePage : ""}
-                  >{pageNumber}</button>
-                );
-              })}
-
-              {/** 다음 페이지 */}
-              <button
-                onClick={goToNextHandler}
-                disabled={currentPage === totalPages}
-                >{">"}</button>
-              {/** 맨 끝 페이지 */}
-              <button
-                onClick={goToLastHandler}
-                disabled={currentPage === totalPages}
-                > {">>"}</button>
-            </div>
-          )}
-        </div>
+          <div className={styles.pagination}>
+            <Pagination 
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
+            />
+          </div>
+        </>
+      ) : (
+        <p className={styles.noData}>기록이 없어요.</p>
+      )}
+    </div>
     </>
   );
 };

--- a/src/pages/LogPage/components/LogList/LogList.module.css
+++ b/src/pages/LogPage/components/LogList/LogList.module.css
@@ -37,6 +37,13 @@
   gap: 20px;
 }
 
+.rowsContainer {display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 400px;
+  gap: 20px;
+}
+
 .row {
   display: flex;
   justify-content: space-around;
@@ -51,6 +58,7 @@
   background: var(--white_FFFFFF);
   font-size: 16px;
   font-weight: 700;
+  gap: 100px;
 }
 
 .rowDate {
@@ -77,7 +85,7 @@
   gap: 8px;
 }
 
-.pagination button {
+/* .pagination button {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -85,20 +93,20 @@
   height: 40px;
   font-size: 18px;
   color: var(--black_414141);
-}
+} */
 
-.pagination button:disabled {
+/* .pagination button:disabled {
   color: var(--gray_818181);
   cursor: default;
   pointer-events: none;
-}
+} */
 
-.pagination button.activePage {
+/* .pagination button.activePage {
   background-color: var(--brand_99C08E);
   color: var(--white_FFFFFF);
   font-weight: bold;
   border-radius: 10px;
-}
+} */
 
 /* .pagination button:hover:not(:disabled):not(.activePage) {
   border-radius: 50%;
@@ -106,7 +114,7 @@
 } */
 
 .noData {
-  margin-top: 100px;
+  margin: auto 0;
   text-align: center;
   color: var(--gray_818181);
 }

--- a/src/services/LogService.js
+++ b/src/services/LogService.js
@@ -1,18 +1,32 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
-export const getLogs = async (id, formattedDate) => {
+export const getLogs = async (id, formattedDate, page = 1) => {
   try {
-    const response = await fetch(`${API_URL}/api/logs/${id}/logs?date=${formattedDate}`);
+    const response = await fetch(`${API_URL}/api/logs/${id}/logs?date=${formattedDate}&page=${page}&pageSize=5`);
     
     if (!response.ok) {
       console.error("데이터 로드 실패:", response.status);
-      return [];
+      return {
+        data: {
+          logs: [],
+          pagination: {
+            totalPages: 1
+          }
+        }
+      };
     }
 
-    const { data } = await response.json();
-    return data || [];
+    const result = await response.json();
+    return result;
   } catch (error) {
     console.error(error);
-    return [];
+    return {
+      data: {
+        logs: [],
+        pagination: {
+          totalPages: 1
+        }
+      }
+    };
   }
 };


### PR DESCRIPTION
## 🔥 Related Issues

- close #159 

---

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

- 로그 페이지의 페이지네이션 부분을 공통 컴포넌트를 사용하는 것으로 변경했습니다.
- 백엔드와 API를 연동했습니다.


---


## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 공통 컴포넌트를 사용하여 페이지네이션 기능을 구현합니다.
- 공통 컴포넌트를 사용함으로 변경된 UI를 기존 페이지대로 수정합니다.
- 기존의 프론트에서 작성했던 페이지네이션 기능(slice 등)을 백엔드에서 불러옵니다.
- 백엔드 API와 프론트를 연동합니다.
   - 기존 로그데이터를 불러오는 fetch를 수정했습니다. (로그 데이터 + 페이지네이션)


---


## 📷 스크린샷 (선택사항)

> 필요한 경우, 스크린샷을 남겨주세요.

- **진입 시 / 맨 처음 페이지**
<img width="957" height="535" alt="image" src="https://github.com/user-attachments/assets/0a7fceef-57b5-44af-bea6-9afef35dba72" />

- **맨 끝페이지로 이동 시**
<img width="958" height="543" alt="image" src="https://github.com/user-attachments/assets/0d16148a-b733-4bcf-ae90-b554122e95c1" />


---


## 📦 참고사항 (선택사항)

> ex: OOO 패키지를 적용했습니다! `npm install ~~~ `

- 기존의 코드는 삭제하고 소정님께서 컴포넌트화 해둔 pagination을 적용했습니다.