### PR TITLE
[Feat] 스켈레톤 UI 추가 및 자잘한 버그 수정

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -48,7 +48,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .btnDefault {
     width: 302px;
   }

--- a/src/components/Loading/DescSkeleton.jsx
+++ b/src/components/Loading/DescSkeleton.jsx
@@ -1,0 +1,12 @@
+import styles from './Loading.module.css';
+
+const DescSkeleton = () => {
+  return (
+    <>
+      <div className={styles.descSkeleton}></div>
+      <div className={styles.descSkeleton}></div>
+    </>
+  );
+};
+
+export default DescSkeleton;

--- a/src/components/Loading/EmojiSkeleton.jsx
+++ b/src/components/Loading/EmojiSkeleton.jsx
@@ -1,0 +1,14 @@
+import styles from './Loading.module.css';
+
+const EmojiSkeleton = () => {
+  return (
+    <div className={styles.emojiMoreBoxSkeleton}>
+      <div className={styles.emojiItemSkeleton}></div>
+      <div className={styles.emojiItemSkeleton}></div>
+      <div className={styles.emojiItemSkeleton}></div>
+      <div className={styles.emojiItemSkeleton}></div>
+    </div>
+  );
+};
+
+export default EmojiSkeleton;

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -35,6 +35,30 @@
   animation: shimmer 1.4s infinite;
 }
 
+.emojiMoreBoxSkeleton {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 7px;
+}
+
+.emojiItemSkeleton {
+  width: 60px;
+  height: 31px;
+  padding: 6px 8px;
+  border-radius: 50px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+.descSkeleton {
+  width: 80%;
+  height: 28px;
+  background: linear-gradient(90deg, #f1f1f1 25%, #e7e7e7 37%, #f1f1f1 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
 @keyframes shimmer {
   0% {
     background-position: 100% 0;

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -52,7 +52,7 @@
   color: var(--red_F50E0E);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .toast {
     padding: 10px 18px;
     font-size: 14px;

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -13,6 +13,7 @@ const useToast = () => {
   const [toasts, setToasts] = useState([]);
 
   const addToast = (type, msg, contentType = 'toast') => {
+    // 같은 contentType 의 메시지가 5번 이상 발생했을 때 return (최대 5개 유지)
     const toastLength = toasts.filter(
       (toast) => toast.contentType === contentType,
     ).length;

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -14,8 +14,11 @@ import {
   getStudyDetail,
   saveRecentStudy,
 } from '../../services/StudyService.js';
+import { getEmojis } from '../../services/EmojiService.js';
+import { getWeeklyHabits } from '../../services/HabitService.js';
 
 import styles from './StudyDetailPage.module.css';
+import NotFound from '../NotFoundPage/NotFound.jsx';
 
 const StudyDetailPage = () => {
   const { id } = useParams();
@@ -23,20 +26,33 @@ const StudyDetailPage = () => {
   const { toasts, addToast } = useToast();
 
   const [study, setStudy] = useState([]);
+  const [emojis, setEmojis] = useState([]);
+  const [habits, setHabits] = useState([]);
 
   const [modalStep, setModalStep] = useState(null);
   const [modalType, setModalType] = useState(null);
 
-  const fetchStudy = async () => {
-    try {
-      const data = await getStudyDetail(id);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isNotFoundPage, setIsNotFoundPage] = useState(false);
 
-      if (!data) {
+  const fetchDatas = async () => {
+    try {
+      const studyData = await getStudyDetail(id);
+
+      if (!studyData) {
+        setIsNotFoundPage(true);
         return;
       }
+      const emojiData = await getEmojis(id);
+      const habitData = await getWeeklyHabits(id);
 
-      setStudy(data);
-      saveRecentStudy(data);
+      setStudy(studyData);
+      setEmojis(emojiData);
+      setHabits(habitData);
+
+      saveRecentStudy(studyData);
+
+      setIsLoading(true);
     } catch (error) {
       console.log(error);
       throw error;
@@ -44,7 +60,7 @@ const StudyDetailPage = () => {
   };
 
   useEffect(() => {
-    fetchStudy();
+    fetchDatas();
   }, []);
 
   // 수정을 눌렀는지 습관을 눌렀는지 로그를 눌렀는지 . . .
@@ -61,43 +77,62 @@ const StudyDetailPage = () => {
   };
 
   return (
-    <div className="wrapper">
-      <div className={styles.ixWrapper}>
-        <Interaction onClick={modalHandler} onShare={shareHandler} />
-        <Emojis toastHandler={addToast} />
-      </div>
+    <>
+      {isNotFoundPage ? (
+        <NotFound />
+      ) : (
+        <div className="wrapper">
+          <div className={styles.ixWrapper}>
+            <Interaction onClick={modalHandler} onShare={shareHandler} />
+            <Emojis
+              toastHandler={addToast}
+              isLoading={isLoading}
+              emojis={emojis}
+              setEmojis={setEmojis}
+            />
+          </div>
 
-      <div className={styles.introWrapper}>
-        <StudyDetail onClick={modalHandler} id={id} study={study} />
-      </div>
+          <div className={styles.introWrapper}>
+            <StudyDetail
+              onClick={modalHandler}
+              id={id}
+              study={study}
+              isLoading={isLoading}
+            />
+          </div>
 
-      <main className={styles.innerWrapper}>
-        <h2 className={styles.tableTitle}>습관 기록표</h2>
+          <main className={styles.innerWrapper}>
+            <h2 className={styles.tableTitle}>습관 기록표</h2>
+            <HabitTable id={id} isLoading={isLoading} habits={habits} />
+          </main>
 
-        <HabitTable id={id} />
-      </main>
+          <Modals
+            id={id}
+            studyInfo={{
+              nickname: study.nickname,
+              title: study.title,
+            }}
+            modalStep={modalStep}
+            setModalStep={setModalStep}
+            modalType={modalType}
+            setModalType={setModalType}
+            toastHandler={addToast}
+          />
 
-      <Modals
-        id={id}
-        studyInfo={{
-          nickname: study.nickname,
-          title: study.title,
-        }}
-        modalStep={modalStep}
-        setModalStep={setModalStep}
-        modalType={modalType}
-        setModalType={setModalType}
-        toastHandler={addToast}
-      />
-
-      {toasts.length > 0 && (
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          {toasts.map((toast) => (
-            <Toast key={toast.id} toastType={toast.type} toastMsg={toast.msg} />
-          ))}
+          {toasts.length > 0 && (
+            <div style={{ display: 'flex', justifyContent: 'center' }}>
+              {toasts.map((toast) => (
+                <Toast
+                  key={toast.id}
+                  toastType={toast.type}
+                  toastMsg={toast.msg}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -32,7 +32,7 @@ const StudyDetailPage = () => {
   const [modalStep, setModalStep] = useState(null);
   const [modalType, setModalType] = useState(null);
 
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [isNotFoundPage, setIsNotFoundPage] = useState(false);
 
   const fetchDatas = async () => {
@@ -52,7 +52,7 @@ const StudyDetailPage = () => {
 
       saveRecentStudy(studyData);
 
-      setIsLoading(true);
+      setIsLoading(false);
     } catch (error) {
       console.log(error);
       throw error;

--- a/src/pages/StudyDetailPage/StudyDetailPage.module.css
+++ b/src/pages/StudyDetailPage/StudyDetailPage.module.css
@@ -28,10 +28,7 @@
   font-size: 24px;
 }
 
-@media (max-width: 1024px) {
-}
-
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .innerWrapper {
     overflow-x: auto;
   }

--- a/src/pages/StudyDetailPage/components/Description/Description.jsx
+++ b/src/pages/StudyDetailPage/components/Description/Description.jsx
@@ -2,6 +2,7 @@ import styles from './Description.module.css';
 import TotalPoint from '../../../../components/TotalPoint/TotalPoint';
 import { useParams } from 'react-router-dom';
 import DescSkeleton from '../../../../components/Loading/DescSkeleton';
+import TotalPointSkeleton from '../../../../components/Loading/TotalPointSkeleton';
 
 const Description = ({
   descTitle,
@@ -14,15 +15,18 @@ const Description = ({
   return (
     <div className={styles.descContainer}>
       <p className={styles.descTitle}>{descTitle}</p>
-      {descType === 'text' ? (
-        isLoading ? (
-          <p className={styles.descContent}>{descContent}</p>
-        ) : (
+      {descType === 'text' &&
+        (isLoading ? (
           <DescSkeleton />
-        )
-      ) : (
-        <TotalPoint id={id} size={'m'} />
-      )}
+        ) : (
+          <p className={styles.descContent}>{descContent}</p>
+        ))}
+      {descType === 'point' &&
+        (isLoading ? (
+          <TotalPointSkeleton />
+        ) : (
+          <TotalPoint id={id} size={'m'} />
+        ))}
     </div>
   );
 };

--- a/src/pages/StudyDetailPage/components/Description/Description.jsx
+++ b/src/pages/StudyDetailPage/components/Description/Description.jsx
@@ -1,15 +1,25 @@
 import styles from './Description.module.css';
 import TotalPoint from '../../../../components/TotalPoint/TotalPoint';
 import { useParams } from 'react-router-dom';
+import DescSkeleton from '../../../../components/Loading/DescSkeleton';
 
-const Description = ({ descTitle, descContent, descType = 'text' }) => {
+const Description = ({
+  descTitle,
+  descContent,
+  descType = 'text',
+  isLoading,
+}) => {
   const { id } = useParams();
 
   return (
     <div className={styles.descContainer}>
       <p className={styles.descTitle}>{descTitle}</p>
       {descType === 'text' ? (
-        <p className={styles.descContent}>{descContent}</p>
+        isLoading ? (
+          <p className={styles.descContent}>{descContent}</p>
+        ) : (
+          <DescSkeleton />
+        )
       ) : (
         <TotalPoint id={id} size={'m'} />
       )}

--- a/src/pages/StudyDetailPage/components/Description/Description.module.css
+++ b/src/pages/StudyDetailPage/components/Description/Description.module.css
@@ -23,7 +23,7 @@
 @media (max-width: 1024px) {
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .descTitle {
     font-size: 16px;
   }

--- a/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
+++ b/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
@@ -24,6 +24,14 @@ const EmojiContainer = ({ toastHandler, emojis, setEmojis, isLoading }) => {
     />
   );
 
+  const updateEmoji = async (emojiId) => {
+    const updateEmoji = await updateEmojis(id, emojiId);
+
+    setEmojis((prev) =>
+      prev.map((p) => (p.emoji !== updateEmoji.emoji ? p : updateEmoji)),
+    );
+  };
+
   return (
     <div className={styles.emojiWrapper}>
       {isLoading ? (
@@ -56,6 +64,7 @@ const EmojiContainer = ({ toastHandler, emojis, setEmojis, isLoading }) => {
         toastHandler={toastHandler}
         emojis={emojis}
         setEmojis={setEmojis}
+        updateEmoji={updateEmoji}
         id={id}
       />
     </div>

--- a/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
+++ b/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
@@ -27,6 +27,8 @@ const EmojiContainer = ({ toastHandler, emojis, setEmojis, isLoading }) => {
   return (
     <div className={styles.emojiWrapper}>
       {isLoading ? (
+        <EmojiSkeleton />
+      ) : (
         <>
           {emojis.slice(0, 3).map((emoji, i) => emojiContent(emoji, i))}
 
@@ -48,8 +50,6 @@ const EmojiContainer = ({ toastHandler, emojis, setEmojis, isLoading }) => {
             </div>
           )}
         </>
-      ) : (
-        <EmojiSkeleton />
       )}
 
       <EmojiAdd

--- a/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
+++ b/src/pages/StudyDetailPage/components/Emoji/EmojiContainer.jsx
@@ -4,30 +4,15 @@ import { useParams } from 'react-router-dom';
 import Emoji from '../../../../components/Emoji/Emoji';
 import EmojiAdd from './EmojiPopOver/EmojiAdd/EmojiAdd';
 
-import { getEmojis, updateEmojis } from '../../../../services/EmojiService';
+import { updateEmojis } from '../../../../services/EmojiService';
 
 import styles from './EmojiContainer.module.css';
 import plusIcon from '../../../../assets/icons/ic_plus.svg';
+import EmojiSkeleton from '../../../../components/Loading/EmojiSkeleton';
 
-const EmojiContainer = ({ toastHandler }) => {
+const EmojiContainer = ({ toastHandler, emojis, setEmojis, isLoading }) => {
   const { id } = useParams();
-  const [emojis, setEmojis] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
-
-  const fetchEmojis = async () => {
-    try {
-      const data = await getEmojis(id);
-
-      setEmojis(data);
-    } catch (error) {
-      console.log(error);
-      throw error;
-    }
-  };
-
-  useEffect(() => {
-    fetchEmojis();
-  }, []);
 
   const emojiContent = (emoji, i) => (
     <Emoji
@@ -39,40 +24,38 @@ const EmojiContainer = ({ toastHandler }) => {
     />
   );
 
-  const updateEmoji = async (emojiId) => {
-    const updateEmoji = await updateEmojis(id, emojiId);
-
-    setEmojis((prev) =>
-      prev.map((p) => (p.emoji !== updateEmoji.emoji ? p : updateEmoji)),
-    );
-  };
-
   return (
     <div className={styles.emojiWrapper}>
-      {emojis.slice(0, 3).map((emoji, i) => emojiContent(emoji, i))}
+      {isLoading ? (
+        <>
+          {emojis.slice(0, 3).map((emoji, i) => emojiContent(emoji, i))}
 
-      {emojis.length > 3 && (
-        <div>
-          <button
-            className={styles.emojiMoreBtn}
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            <img src={plusIcon} alt="이모지 더보기" /> {emojis.slice(3).length}
-            ..
-          </button>
-          {isOpen && (
-            <div className={styles.emojiMoreBox}>
-              {emojis.slice(3).map((emoji, i) => emojiContent(emoji, i))}
+          {emojis.length > 3 && (
+            <div>
+              <button
+                className={styles.emojiMoreBtn}
+                onClick={() => setIsOpen(!isOpen)}
+              >
+                <img src={plusIcon} alt="이모지 더보기" />{' '}
+                {emojis.slice(3).length}
+                ..
+              </button>
+              {isOpen && (
+                <div className={styles.emojiMoreBox}>
+                  {emojis.slice(3).map((emoji, i) => emojiContent(emoji, i))}
+                </div>
+              )}
             </div>
           )}
-        </div>
+        </>
+      ) : (
+        <EmojiSkeleton />
       )}
 
       <EmojiAdd
         toastHandler={toastHandler}
         emojis={emojis}
         setEmojis={setEmojis}
-        updateEmoji={updateEmoji}
         id={id}
       />
     </div>

--- a/src/pages/StudyDetailPage/components/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
+++ b/src/pages/StudyDetailPage/components/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
@@ -1,15 +1,12 @@
 import { useRef, useState } from 'react';
 import EmojiPicker from 'emoji-picker-react';
 
-import {
-  createEmojis,
-  updateEmojis,
-} from '../../../../../../services/EmojiService';
+import { createEmojis } from '../../../../../../services/EmojiService';
 
 import styles from '../../EmojiContainer.module.css';
 import smileIcon from '../../../../../../assets/icons/ic_smile.svg';
 
-const EmojiAdd = ({ emojis, setEmojis, id, toastHandler }) => {
+const EmojiAdd = ({ emojis, setEmojis, updateEmoji, id, toastHandler }) => {
   const [isOpen, setIsOpen] = useState(false);
   const emojiRef = useRef(null);
 
@@ -35,14 +32,6 @@ const EmojiAdd = ({ emojis, setEmojis, id, toastHandler }) => {
       //update emoji id 같이
       updateEmoji(selectEmoji.id);
     }
-  };
-
-  const updateEmoji = async (emojiId) => {
-    const updateEmoji = await updateEmojis(id, emojiId);
-
-    setEmojis((prev) =>
-      prev.map((p) => (p.emoji !== updateEmoji.emoji ? p : updateEmoji)),
-    );
   };
 
   return (

--- a/src/pages/StudyDetailPage/components/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
+++ b/src/pages/StudyDetailPage/components/Emoji/EmojiPopOver/EmojiAdd/EmojiAdd.jsx
@@ -9,7 +9,7 @@ import {
 import styles from '../../EmojiContainer.module.css';
 import smileIcon from '../../../../../../assets/icons/ic_smile.svg';
 
-const EmojiAdd = ({ emojis, setEmojis, id, updateEmoji, toastHandler }) => {
+const EmojiAdd = ({ emojis, setEmojis, id, toastHandler }) => {
   const [isOpen, setIsOpen] = useState(false);
   const emojiRef = useRef(null);
 
@@ -35,6 +35,14 @@ const EmojiAdd = ({ emojis, setEmojis, id, updateEmoji, toastHandler }) => {
       //update emoji id 같이
       updateEmoji(selectEmoji.id);
     }
+  };
+
+  const updateEmoji = async (emojiId) => {
+    const updateEmoji = await updateEmojis(id, emojiId);
+
+    setEmojis((prev) =>
+      prev.map((p) => (p.emoji !== updateEmoji.emoji ? p : updateEmoji)),
+    );
   };
 
   return (

--- a/src/pages/StudyDetailPage/components/HabitTable/HabitTable.jsx
+++ b/src/pages/StudyDetailPage/components/HabitTable/HabitTable.jsx
@@ -9,35 +9,33 @@ const HabitTable = ({ id, isLoading, habits }) => {
   return (
     <>
       {isLoading ? (
-        habits.length === 0 ? (
-          <p className={styles.emptyTable}>
-            아직 습관이 없어요
-            <br />
-            오늘의 습관에서 습관을 생성해보세요
-          </p>
-        ) : (
-          <table className={styles.habitTable}>
-            <thead>
-              <tr>
-                <th></th>
-                <th>월</th>
-                <th>화</th>
-                <th>수</th>
-                <th>목</th>
-                <th>금</th>
-                <th>토</th>
-                <th>일</th>
-              </tr>
-            </thead>
-            <tbody>
-              <HabitItems datas={habits} />
-            </tbody>
-          </table>
-        )
-      ) : (
         <div className={styles.emptyTable}>
           <ContentSpinner />
         </div>
+      ) : habits.length === 0 ? (
+        <p className={styles.emptyTable}>
+          아직 습관이 없어요
+          <br />
+          오늘의 습관에서 습관을 생성해보세요
+        </p>
+      ) : (
+        <table className={styles.habitTable}>
+          <thead>
+            <tr>
+              <th></th>
+              <th>월</th>
+              <th>화</th>
+              <th>수</th>
+              <th>목</th>
+              <th>금</th>
+              <th>토</th>
+              <th>일</th>
+            </tr>
+          </thead>
+          <tbody>
+            <HabitItems datas={habits} />
+          </tbody>
+        </table>
       )}
     </>
   );

--- a/src/pages/StudyDetailPage/components/HabitTable/HabitTable.jsx
+++ b/src/pages/StudyDetailPage/components/HabitTable/HabitTable.jsx
@@ -2,49 +2,42 @@ import { useEffect, useState } from 'react';
 
 import HabitItems from './HabitItems/HabitItems';
 
-import { getWeeklyHabits } from '../../../../services/HabitService';
-
 import styles from '../HabitTable/HabitTable.module.css';
+import ContentSpinner from '../../../../components/Loading/ContentSpinner';
 
-const HabitTable = ({ id }) => {
-  const [habits, setHabits] = useState([]);
-
-  const fetchData = async () => {
-    const data = await getWeeklyHabits(id);
-
-    setHabits(data);
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
-
+const HabitTable = ({ id, isLoading, habits }) => {
   return (
     <>
-      {habits.length === 0 ? (
-        <p className={styles.emptyTable}>
-          아직 습관이 없어요
-          <br />
-          오늘의 습관에서 습관을 생성해보세요
-        </p>
+      {isLoading ? (
+        habits.length === 0 ? (
+          <p className={styles.emptyTable}>
+            아직 습관이 없어요
+            <br />
+            오늘의 습관에서 습관을 생성해보세요
+          </p>
+        ) : (
+          <table className={styles.habitTable}>
+            <thead>
+              <tr>
+                <th></th>
+                <th>월</th>
+                <th>화</th>
+                <th>수</th>
+                <th>목</th>
+                <th>금</th>
+                <th>토</th>
+                <th>일</th>
+              </tr>
+            </thead>
+            <tbody>
+              <HabitItems datas={habits} />
+            </tbody>
+          </table>
+        )
       ) : (
-        <table className={styles.habitTable}>
-          <thead>
-            <tr>
-              <th></th>
-              <th>월</th>
-              <th>화</th>
-              <th>수</th>
-              <th>목</th>
-              <th>금</th>
-              <th>토</th>
-              <th>일</th>
-            </tr>
-          </thead>
-          <tbody>
-            <HabitItems datas={habits} />
-          </tbody>
-        </table>
+        <div className={styles.emptyTable}>
+          <ContentSpinner />
+        </div>
       )}
     </>
   );

--- a/src/pages/StudyDetailPage/components/HabitTable/HabitTable.module.css
+++ b/src/pages/StudyDetailPage/components/HabitTable/HabitTable.module.css
@@ -40,7 +40,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .habitTable {
     width: 1024px;
   }

--- a/src/pages/StudyDetailPage/components/Interaction/Interaction.module.css
+++ b/src/pages/StudyDetailPage/components/Interaction/Interaction.module.css
@@ -19,12 +19,11 @@
   justify-content: center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .greenText,
   .grayText {
     font-size: 12px;
   }
-
   .interContainer {
     justify-content: flex-end;
     margin-bottom: 16px;

--- a/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
@@ -6,15 +6,21 @@ import Description from '../Description/Description';
 import icArrowRight from '../../../../assets/icons/ic_arrow_right.svg';
 
 import styles from './StudyDetail.module.css';
+import StudyNameSkeleton from '../../../../components/Loading/StudyNameSkeleton';
 
-const StudyDetail = ({ onClick, id, study }) => {
+const StudyDetail = ({ onClick, id, study, isLoading }) => {
   return (
     <>
       <div className={styles.titleContainer}>
-        <h1 className={styles.title}>
-          <span>{study.nickname}의 </span>
-          <span>{study.title}</span>
-        </h1>
+        {isLoading ? (
+          <h1 className={styles.title}>
+            <span>{study.nickname}의 </span>
+            <span>{study.title}</span>
+          </h1>
+        ) : (
+          <StudyNameSkeleton />
+        )}
+
         <div className={styles.btnContainer}>
           <LinkButton
             text="로그"
@@ -35,7 +41,11 @@ const StudyDetail = ({ onClick, id, study }) => {
       </div>
 
       <div className={styles.descWrapper}>
-        <Description descTitle={'소개'} descContent={study.description} />
+        <Description
+          descTitle={'소개'}
+          descContent={study.description}
+          isLoading={isLoading}
+        />
         <Description descType={'point'} descTitle={'현재까지 획득한 포인트'} />
       </div>
     </>

--- a/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
@@ -13,12 +13,12 @@ const StudyDetail = ({ onClick, id, study, isLoading }) => {
     <>
       <div className={styles.titleContainer}>
         {isLoading ? (
+          <StudyNameSkeleton />
+        ) : (
           <h1 className={styles.title}>
             <span>{study.nickname}의 </span>
             <span>{study.title}</span>
           </h1>
-        ) : (
-          <StudyNameSkeleton />
         )}
 
         <div className={styles.btnContainer}>

--- a/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.module.css
+++ b/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.module.css
@@ -28,7 +28,7 @@
   gap: 24px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .titleContainer {
     flex-direction: column;
     align-items: flex-start;

--- a/src/styles/pattern.css
+++ b/src/styles/pattern.css
@@ -84,7 +84,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .wrapper {
     padding: 16px;
   }


### PR DESCRIPTION

## 📋 PR 기본 정보

- **프로젝트**: 초급
- **주차**: 3주차
- **PR 요약**: 구현한 기능 혹은 해당 PR의 내용을 요약

스켈레톤 UI 추가 및 자잘한 버그 수정하였습니다.

## 🛠️ 구현 내용

> 이번 PR에서 구현하거나 수정한 내용을 간략히 설명해 주세요.

- 반응형 수정 (767px)
- 스켈레톤 UI 추가
- not found ui 추가
- 데이터 한 번에 관리할 수 있도록 모든 fetch data study detail page 에 옮김

## 🔍 코드리뷰 요청 사항

> **코드리뷰 멘토에게 피드백 받고 싶은 부분을 구체적으로 작성해 주세요.**
> 파일명, 라인 번호, 함수명 등을 함께 적어주시면 멘토가 집중해서 볼 수 있습니다.

### 요청 1
- **파일/위치**: `src/pages/StudyDetailPage/StudyDetailPage.jsx`
- **요청 내용**: 
  > 스켈레톤 UI 를 위한 isLoading 처리에 관한 내용입니다!
  
스터디 상세 조회 페이지에는 총 3가지의 api 호출이 존재합니다.

1. 스터디
2. 이모지
3. 습관

원래는 이 api 호출 및 state 선언 부분을 각각의 컴포넌트에서 실행되도록 했었는데, 로딩 처리가 생기면서 스터디, 이모지, 습관의 호출이 동시에 끝나는 시점에 로딩이 끝나게 되어야할 것 같아 제일 상위 컴포넌트에 모든 api 호출 및 state 선언을 처리하게 되었습니다.
상위 컴포넌트에서 api 호출을 처리하게되어 불필요한 props 를 넘기게 된건지 아닌지 고민이 되었었습니다.
  
- **고민한 점**: 
처음엔 loading 배열을 생성하여 하위 컴포넌트들에서 api 호출이 시작될 때 loading에 값을 넣고 끝날 때 loading 에서 값을 삭제하여 관리하려고 했었습니다.
그런데 이건 이것대로 props 를 꽤 많이 내려줘야하는 상황이 생기더라구요.. 
차라리 서버쪽에서 study 안에 이모지와 습관 정보를 같이 넘겨줘야할까요? (이 부분은 너무 불필요한 서버 연산 작업이 들어가지 않나 싶어 작업을 해두진 않았었습니다!)