### PR TITLE
[Refactor] 스터디 데이터에서 총합 포인트 조회 가능하도록 수정

### DIFF
--- a/src/pages/StudyListPage/StudyComponents/Card.jsx
+++ b/src/pages/StudyListPage/StudyComponents/Card.jsx
@@ -62,7 +62,11 @@ const Card = ({ study }) => {
                 의 {study.title}
               </h3>
               {/* 획득 포인트 연결 */}
-              <TotalPoint id={study.id} theme={pointTheme} />
+              <TotalPoint
+                theme={pointTheme}
+                isIndividual={true}
+                points={study.rewardPoint}
+              />
             </div>
 
             {/* N일째 진행 중 */}

--- a/src/services/StudyService.js
+++ b/src/services/StudyService.js
@@ -36,7 +36,7 @@ const normalizeStudy = (study) => ({
   createdAt: study.createdAt ?? '',
   updatedAt: study.updatedAt ?? '',
   progressText: study.progressText || getStudyProgressText(study.createdAt),
-  rewardPoint: study.rewardPoint ?? 0,
+  rewardPoint: study.totalPoint ?? 0,
   commentCount: study.commentCount ?? 0,
   fireCount: study.fireCount ?? 0,
   heartCount: study.heartCount ?? 0,


### PR DESCRIPTION
## 🔥 Related Issues

- close #171 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

각 스터디 목록을 렌더링할때마다 총합포인트를 fetch하는 문제를 보완하기 위해 스터디 데이터에 총합 포인트도 조회되도록 수정

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- normalizeStudy에 totalPoint를 조회할 수 있도록 수정
- 공통 총합 포인트 컴포넌트에 이 값을 넣어 불필요한 fetch 안되게 수정

## 📷 스크린샷 
### 1. 수정 전, 총합 포인트 조회 fetch가 스터디 목록 수 만큼 실행
<img width="1382" height="802" alt="2_불필요한_fetch_수정" src="https://github.com/user-attachments/assets/8d7c5be8-cc06-4fc2-823b-e6b68c3b8327" />

### 2. 수정 후, 불필요한 fetch 실행되지 않음 
<img width="1386" height="819" alt="1_불필요한_fetch_수정" src="https://github.com/user-attachments/assets/c508335a-a200-4716-a430-525880b9ad43" />

