### PR TITLE
[Feat] 메인, 상세 조회 페이지로 이동 시, 비밀번호 인증 초기화 되도록 구현

### DIFF
--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -35,6 +35,9 @@ const StudyDetailPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isNotFoundPage, setIsNotFoundPage] = useState(false);
 
+  // 세션스토리지에 저장된 비밀번호 인증 초기화
+  sessionStorage.clear();
+
   const fetchDatas = async () => {
     try {
       const studyData = await getStudyDetail(id);

--- a/src/pages/StudyListPage/StudyListPage.jsx
+++ b/src/pages/StudyListPage/StudyListPage.jsx
@@ -22,6 +22,9 @@ const StudyList = () => {
     totalPages: 1,
   });
 
+  // 세션스토리지에 저장된 비밀번호 인증 초기화
+  sessionStorage.clear();
+
   useEffect(() => {
     const fetchStudyList = async () => {
       setIsLoading(true);


### PR DESCRIPTION
## 🔥 Related Issues

- close #173 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

Before : 상세 조회 페이지에서 비밀번호를 한번만 인증하면,  로그, 습관, 집중 페이지에 비밀번호 검증 없이 url로 직접 접근 가능

After : 상세 조회 페이지에서 비밀번호 인증 후, 다시 홈이나 상세 조회 페이지로 이동하면 비밀번호 인증 초기화


## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

- 홈, 상세 조회 페이지에 `sessionStorage.clear();`를 추가하여 세션스토리지에 저장된 비밀번호 인증 데이터를 삭제

