### PR TITLE
[Feat] 습관 생성 시간 및 끝난 시간 토대로 테이블에 표시되지 않게끔 구현

### DIFF
--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -41,6 +41,10 @@
   margin-top: 16px;
 }
 
+.totalPointTitleNone {
+  display: none;
+}
+
 .totalPointTitleSkeleton {
   width: 165px;
   height: 27px;

--- a/src/components/Loading/TotalPointSkeleton.jsx
+++ b/src/components/Loading/TotalPointSkeleton.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import styles from './Loading.module.css';
 
-const TotalPointSkeleton = () => {
+const TotalPointSkeleton = ({ isTitleOn = false }) => {
   return (
     <div className={styles.totalPointSkeletonContainer}>
-      <div className={styles.totalPointTitleSkeleton}></div>
+      <div
+        className={
+          isTitleOn
+            ? styles.totalPointTitleNone
+            : styles.totalPointTitleSkeleton
+        }
+      ></div>
       <div className={styles.totalPointSkeleton}></div>
     </div>
   );

--- a/src/pages/StudyDetailPage/StudyDetailPage.jsx
+++ b/src/pages/StudyDetailPage/StudyDetailPage.jsx
@@ -26,6 +26,7 @@ const StudyDetailPage = () => {
   const { toasts, addToast } = useToast();
 
   const [study, setStudy] = useState([]);
+  const [points, setPoints] = useState([]);
   const [emojis, setEmojis] = useState([]);
   const [habits, setHabits] = useState([]);
 
@@ -44,14 +45,15 @@ const StudyDetailPage = () => {
         return;
       }
 
-      saveRecentStudy(studyData);
+      saveRecentStudy(studyData.study);
 
       Promise.all([getEmojis(id), getWeeklyHabits(id)])
         .then((values) => {
           const emojiData = values[0];
           const habitData = values[1];
 
-          setStudy(studyData);
+          setStudy(studyData.study);
+          setPoints(studyData.points);
           setEmojis(emojiData);
           setHabits(habitData);
         })
@@ -100,6 +102,7 @@ const StudyDetailPage = () => {
               onClick={modalHandler}
               id={id}
               study={study}
+              points={points}
               isLoading={isLoading}
             />
           </div>

--- a/src/pages/StudyDetailPage/components/Description/Description.jsx
+++ b/src/pages/StudyDetailPage/components/Description/Description.jsx
@@ -3,14 +3,25 @@ import TotalPoint from '../../../../components/TotalPoint/TotalPoint';
 import { useParams } from 'react-router-dom';
 import DescSkeleton from '../../../../components/Loading/DescSkeleton';
 import TotalPointSkeleton from '../../../../components/Loading/TotalPointSkeleton';
+import { useEffect } from 'react';
 
 const Description = ({
   descTitle,
   descContent,
   descType = 'text',
   isLoading,
+  points,
 }) => {
   const { id } = useParams();
+
+  const pointsHandler = () => {
+    if (!points) {
+      return;
+    }
+    const sum = points.map((point) => point.points).reduce((a, b) => a + b, 0);
+
+    return sum;
+  };
 
   return (
     <div className={styles.descContainer}>
@@ -23,9 +34,14 @@ const Description = ({
         ))}
       {descType === 'point' &&
         (isLoading ? (
-          <TotalPointSkeleton />
+          <TotalPointSkeleton isTitleOn={true} />
         ) : (
-          <TotalPoint id={id} size={'m'} />
+          <TotalPoint
+            id={id}
+            size={'m'}
+            isIndividual={true}
+            points={pointsHandler()}
+          />
         ))}
     </div>
   );

--- a/src/pages/StudyDetailPage/components/HabitTable/HabitItems/HabitItems.jsx
+++ b/src/pages/StudyDetailPage/components/HabitTable/HabitItems/HabitItems.jsx
@@ -11,7 +11,9 @@ const HabitItems = ({ datas }) => {
               const count = d_i % 18;
               return (
                 <td key={`complete-${c_i}`}>
-                  {complete ? (
+                  {complete === 'none' ? (
+                    ''
+                  ) : complete ? (
                     <img src={`/stickers/ic_sticker_${count}.svg`} alt="완료" />
                   ) : (
                     <img src={stickerEmpty} alt="완료 못함" />

--- a/src/pages/StudyDetailPage/components/HabitTable/HabitTable.module.css
+++ b/src/pages/StudyDetailPage/components/HabitTable/HabitTable.module.css
@@ -21,6 +21,10 @@
   text-align: right;
 }
 
+.habitTable td {
+  width: 10%;
+}
+
 .habitTable td > img {
   margin: 14px auto;
 }

--- a/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
+++ b/src/pages/StudyDetailPage/components/StudyDetail/StudyDetail.jsx
@@ -8,7 +8,7 @@ import icArrowRight from '../../../../assets/icons/ic_arrow_right.svg';
 import styles from './StudyDetail.module.css';
 import StudyNameSkeleton from '../../../../components/Loading/StudyNameSkeleton';
 
-const StudyDetail = ({ onClick, id, study, isLoading }) => {
+const StudyDetail = ({ onClick, id, study, points, isLoading }) => {
   return (
     <>
       <div className={styles.titleContainer}>
@@ -46,7 +46,12 @@ const StudyDetail = ({ onClick, id, study, isLoading }) => {
           descContent={study.description}
           isLoading={isLoading}
         />
-        <Description descType={'point'} descTitle={'현재까지 획득한 포인트'} />
+        <Description
+          descType={'point'}
+          descTitle={'현재까지 획득한 포인트'}
+          isLoading={isLoading}
+          points={points}
+        />
       </div>
     </>
   );

--- a/src/services/HabitService.js
+++ b/src/services/HabitService.js
@@ -23,9 +23,20 @@ export const getWeeklyHabits = async (id) => {
     const DAYS_IN_WEEK = 7;
     const compeletedDays = new Array(DAYS_IN_WEEK).fill(false);
 
+    if (isThisWeek(habit.startDate)) {
+      const startDay = dayHandeler(habit.startDate);
+
+      compeletedDays.fill('none', 0, startDay);
+    }
+
+    if (habit.endDate !== null && isThisWeek(habit.endDate)) {
+      const endDay = dayHandeler(habit.endDate);
+
+      compeletedDays.fill('none', endDay);
+    }
+
     const days = habit.records.forEach((record) => {
-      const date = new Date(record.date);
-      const day = (date.getDay() + 6) % 7; // date 는 일요일 시작이라 1 빼줌
+      const day = dayHandeler(record.date);
 
       compeletedDays[day] = record.isCompleted;
       return;
@@ -35,6 +46,31 @@ export const getWeeklyHabits = async (id) => {
   });
 
   return weeklyHabits;
+};
+
+const isThisWeek = (date) => {
+  const now = new Date();
+  const target = new Date(date);
+
+  // 현재 주의 월요일 구하기
+  const dayOfWeek = now.getDay(); // 0(일) ~ 6(토)
+  const sundayDiff = now.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1); // 일요일이면 -6, 나머지 +1
+  const startOfWeek = new Date(now.setDate(sundayDiff));
+  startOfWeek.setHours(0, 0, 0, 0);
+
+  // 현재 주의 일요일 구하기
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(startOfWeek.getDate() + 6);
+  endOfWeek.setHours(23, 59, 59, 999);
+
+  return target >= startOfWeek && target <= endOfWeek;
+};
+
+const dayHandeler = (date) => {
+  const target = new Date(date);
+  const day = (target.getDay() + 6) % 7; // date 는 일요일 시작이라 1 빼줌
+
+  return day;
 };
 
 // 습관 생성


### PR DESCRIPTION
## 🔥 Related Issues

- close #176 

## 📒 설명

> 이번 PR에 대한 간략한 설명을 작성해주세요.

습관 생성 시간 및 끝난 시간 토대로 테이블 표시 다르게 구현하였습니다.

## 🛠️ 작업 내용

> 이번 PR에서 구현하거나 수정한 내용을 작성해주세요.

**AS-IS**
- 총 포인트를 따로 api 를 통해 가져옴
- 습관 테이블에 이번주 내에 완료했는데 종료된 습관은 남아있음
- 습관 테이블에 이번주 내에 시작하거나 종료된 습관은 언제 시작되고 종료되는지 알 수 없음
<img width="1143" height="540" alt="image" src="https://github.com/user-attachments/assets/0295663b-3f5a-4626-a96b-89da03901b42" />

**TO-BE**
- 총 포인트를 스터디 상세 정보 값에 포함하여 points api를 따로 불러오지 않도록 수정
- 습관 테이블에서 이번주 내에 완료하였는데 종료되었다면 그 날 제외한  뒷 날짜의 스티커를 테이블에서 제외
- 습관 테이블에서 이번주 내에 시작한 습관 또한 그 날을 제외한 앞 날짜들의 스티커를 테이블에서 제외
<img width="1145" height="544" alt="image" src="https://github.com/user-attachments/assets/fa6d8553-fa2c-4aaa-97ad-999838a6d0f2" />